### PR TITLE
Added checks to make sure $key and Auth::user() are present. Save null i...

### DIFF
--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -109,9 +109,9 @@ class Revisionable extends \Eloquent
                 $revision->revisionable_type = get_class($this);
                 $revision->revisionable_id   = $this->id;
                 $revision->key               = $key;
-                $revision->old_value         = $this->originalData[$key];
+                $revision->old_value         = (isset($this->originalData[$key]) ? $this->originalData[$key]: null);
                 $revision->new_value         = $this->updatedData[$key];
-                $revision->user_id           = \Auth::user()->id;
+                $revision->user_id           = (\Auth::user() ? \Auth::user()->id : null);
                 $revision->save();
 
             }


### PR DESCRIPTION
I came across two exceptions when running a seed script. Both occur in the afterSave method.

The first is an undefined index Revisionable.php line 112. Occurs because the originalData array does not contain the new items key.

The second is trying to get property of non-object on line 114. Auth::user() will return null as no User will be present when running seed files via artisan.

Quick fix to prevent Exceptions when updating Revisionable models in a seed file Issue #12.

Setting the user id to null will cause issues. Calls to $history->userResponsible()->first_name will throw errors if checks are not in place. Suggest there's some sort of fallback user for this situation, or if a user is removed after making changes.
