### PR TITLE
Temporarily disabling a revisionable field

### DIFF
--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -185,4 +185,19 @@ class Revisionable extends \Eloquent
         return $this->id;
     }
 
+    /**
+     * Disable a revisionable field temporarily
+     * 
+     * @param mixed $field
+     * 
+     * @return void
+     */
+    public function disableRevisionField($field)
+    {
+        if(is_array($field))
+            $this->dontKeepRevisionOf = array_merge($field, $this->dontKeepRevisionOf);
+        else
+            $this->dontKeepRevisionOf[] = $field;
+    }
+
 }


### PR DESCRIPTION
Sometimes temporarily disabling a revisionable field can come in handy, I've used this quite often in my application.

```
$object->disableRevisionField('title'); // Disables title
```

or:

```
$object->disableRevisionField(array('title', 'content')); // Disables title and content
```
