### PR TITLE
Add pre-formatted history function to Revision model

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -167,6 +167,14 @@ class Revision extends \Eloquent
         }
     }
 
+    /**
+    * Revision History Pre-formatted
+    * @return RevisionHistory full revision history pre-formatted string
+    */
+    public function preFormatted($date = null)
+    {
+        return $this->userResponsible() . ' changed ' . $this->fieldName() . ' from ' . $this->oldValue() . ' to ' . $this->newValue() . ( $date && $this->created_at ? ' on ' . $this->created_at->format('l jS \\of F Y \\a\t h:i:s A') : '' ) ;
+    }
 
     /*
      * Egzamples:


### PR DESCRIPTION
This commit closes #4.

Added pre-formatted function to Revision Model to make it easier to display multiple histories consistently across views. You can still display the revision history as before, putting all of the formatting in the view:

```
@foreach($account->revisionHistory as $history )
    <li>{{ $history->userResponsible()->first_name }} changed {{ $history->fieldName() }} from {{ $history->oldValue() }} to {{ $history->newValue() }}</li>
@endforeach
```

but you can now also display pre-formatted revision history with:

```
@foreach( $account->revisionHistory as $history )
    {{ $history->preFormatted('date') }}
@endforeach
```

And the optional 'date' variable just adds the revision history date to the format. If triggered, it pulls from the model's 'created_at' column. In case the model doesn't include Laravel's 'created_at' and 'updated_at' fields, it just ignores the date trigger instead of throwing an error.

And the pre-format is specified in Revision Model (Revision.php).
