### PR TITLE
Update trait to use boot<TRAIT NAME> instead of defining a static boot function.

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -28,10 +28,8 @@ trait RevisionableTrait
      * http method.
      *
      */
-    public static function boot()
+    public static function bootRevisionableTrait()
     {
-        parent::boot();
-
         static::saving(function ($model) {
             $model->preSave();
         });


### PR DESCRIPTION
Hey Chris, this pull request is to make the trait works better with model, whereby if models define their own static boot function, the one defined in traits will not be used. By defining "trait boot" function, this will guarantee (within certain parameter) that the "trait boot" static function will always be called.
