### PR TITLE
[FIX] Fixed wrong Sentinel FQCN.

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -179,7 +179,7 @@ class Revision extends Eloquent
     public function userResponsible()
     {
         if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
-                || class_exists($class = '\Cartalyst\Sentinel\Facades\Laravel\Sentinel')) {
+                || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')) {
             return $class::findUserById($this->user_id);
         } else {
             $user_model = Config::get('auth.model');

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -170,7 +170,7 @@ class Revisionable extends Eloquent
     {
         try {
             if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
-                    || class_exists($class = '\Cartalyst\Sentinel\Facades\Laravel\Sentinel')) {
+                    || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')) {
                 return ($class::check()) ? $class::getUser()->id : null;
             } elseif (\Auth::check()) {
                 return \Auth::user()->getAuthIdentifier();

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -168,7 +168,7 @@ trait RevisionableTrait
     {
         try {
             if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
-                    || class_exists($class = '\Cartalyst\Sentinel\Facades\Laravel\Sentinel')) {
+                    || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')) {
                 return ($class::check()) ? $class::getUser()->id : null;
             } elseif (\Auth::check()) {
                 return \Auth::user()->getAuthIdentifier();


### PR DESCRIPTION
Hey mate,

I noticed just now that when I pushed PR #94, I had previously tested changing my `vendor/` files. When I forked, however, I did the edits by hand, and I didn't noticed that I typed the wrong Sentinel FQCN, which is a bit confusing since it's different than Sentry way.

My apologies for not having noticed this before. I was updating my `vendor/` with upstream right now and I just realized it suddenly stopped to work. So I've found my fault.

This fixes the mistake. Apologies for the inconvenience!
