### PR TITLE
Added action to determine type of revision & Much More

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "venturecraft/revisionable",
     "license": "MIT",
-    "description": "Keep a revision history for your models without thinking, created as a package for use with Laravel 4",
+    "description": "Keep a revision history for your models without thinking, created as a package for use with Laravel",
     "keywords": ["model", "laravel", "ardent", "revision", "history"],
     "homepage": "http://github.com/venturecraft/revisionable",
     "authors": [
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "~4.0"
+        "illuminate/support": "~4.0|~5.0|~5.1"
     },
     "autoload": {
         "classmap": [

--- a/readme.md
+++ b/readme.md
@@ -298,6 +298,14 @@ if ($revision->action() == Venturecraft\Revisionable\Revision::UPDATE)
    //Do update related stuff
 ```
 
+### primaryIdentifierName()
+
+(Documentation coming soon)
+
+### primaryIdentifierValue()
+
+(Documentation coming soon)
+
 ### Unknown or invalid foreign keys as revisions
 In cases where the old or new version of a value is a foreign key that no longer exists, or indeed was null, there are two variables that you can set in your model to control the output in these situations:
 

--- a/readme.md
+++ b/readme.md
@@ -277,16 +277,25 @@ Get the value of the model before or after the update. If it was a foreign key, 
 Returns the type of action performed on the model.
 Actions available: CREATE, INSERT, UPDATE, DELETE, REMOVE
 
-CREATE - created new instance of model in table. e.g: create new row in 'customer' table.
-INSERT - added new data of model in table. e.g: add name 'foo' to 'customer' row.
-UPDATE - changed data value in table. e.g: change name from 'foo' to 'faa' in 'customer' row.
-DELETE - removed data value in table. e.g: removed name 'faa' in 'customer' row.
-REMOVE - delete row in table. e.g: delete row in 'customer' table where name is 'faa'.
+* CREATE - created new instance of model in table. e.g: create new row in 'customer' table.
+* INSERT - added new data of model in table. e.g: add name 'foo' to 'customer' row.
+* UPDATE - changed data value in table. e.g: change name from 'foo' to 'faa' in 'customer' row.
+* DELETE - removed data value in table. e.g: removed name 'faa' in 'customer' row.
+* REMOVE - delete row in table. e.g: delete row in 'customer' table where name is 'faa'.
 
 Constants are available for referencing from class 'Revision'.
 E.g: to use constant CREATE 
 ```php
 Venturecraft\Revisionable\Revision::CREATE
+```
+
+Use Case Example:
+
+```php
+//If revision is an 'update' action
+if ($revision->action() == Venturecraft\Revisionable\Revision::UPDATE)
+{
+   //Do update related stuff
 ```
 
 ### Unknown or invalid foreign keys as revisions

--- a/readme.md
+++ b/readme.md
@@ -1,9 +1,5 @@
 # Revisionable
 
-This Fork allows you to save newly created data in database by using the attribute 'public keepCreateRevision=true' in your revisionable classes.
-
-It also allows you to use custom accessors for eloquent classes which goes as 'getFooRevisionAttribute', and falls back to default eloquent accessors.
-
 <a href="https://packagist.org/packages/venturecraft/revisionable">
     <img src="http://img.shields.io/packagist/v/venturecraft/revisionable.svg?style=flat" style="vertical-align: text-top">
 </a>
@@ -143,6 +139,24 @@ protected $dontKeepRevisionOf = array(
 
 > The `$keepRevisionOf` setting takes precendence over `$dontKeepRevisionOf`
 
+<a name="createrevision"></a>
+## Create Revision
+
+If you wish to store revision of the creation of new instances of a model in its table (i.e sql INSERTs), set attribute $saveCreateRevision to TRUE;
+
+```php
+protected $saveCreateRevision = true;
+```
+
+<a name="classname"></a>
+## Class Name
+
+To provide a user-readable name for your eloquent classes, set attribute $revisionClassName to the desired name (expected format: string).
+
+```php
+protected $revisionClassName = "Foo Form";
+```
+
 <a name="formatoutput"></a>
 ## Format output
 
@@ -257,6 +271,23 @@ class Article extends Revisionable
 ### oldValue() and newValue()
 
 Get the value of the model before or after the update. If it was a foreign key, identifiableName() is called.
+
+### action()
+
+Returns the type of action performed on the model.
+Actions available: CREATE, INSERT, UPDATE, DELETE, REMOVE
+
+CREATE - created new instance of model in table. e.g: create new row in 'customer' table.
+INSERT - added new data of model in table. e.g: add name 'foo' to 'customer' row.
+UPDATE - changed data value in table. e.g: change name from 'foo' to 'faa' in 'customer' row.
+DELETE - removed data value in table. e.g: removed name 'faa' in 'customer' row.
+REMOVE - delete row in table. e.g: delete row in 'customer' table where name is 'faa'.
+
+Constants are available for referencing from class 'Revision'.
+E.g: to use constant CREATE 
+```php
+Venturecraft\Revisionable\Revision::CREATE
+```
 
 ### Unknown or invalid foreign keys as revisions
 In cases where the old or new version of a value is a foreign key that no longer exists, or indeed was null, there are two variables that you can set in your model to control the output in these situations:

--- a/readme.md
+++ b/readme.md
@@ -1,5 +1,9 @@
 # Revisionable
 
+This Fork allows you to save newly created data in database by using the attribute 'public keepCreateRevision=true' in your revisionable classes.
+
+It also allows you to use custom accessors for eloquent classes which goes as 'getFooRevisionAttribute', and falls back to default eloquent accessors.
+
 <a href="https://packagist.org/packages/venturecraft/revisionable">
     <img src="http://img.shields.io/packagist/v/venturecraft/revisionable.svg?style=flat" style="vertical-align: text-top">
 </a>

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -125,7 +125,7 @@ class Revision extends Eloquent
 
             $main_model = new $main_model;
 
-            try {
+            /*try {
                 if (strpos($this->key, '_id')) {
 
                     $related_model = str_replace('_id', '', $this->key);
@@ -175,7 +175,7 @@ class Revision extends Eloquent
                 // Just a failsafe, in the case the data setup isn't as expected
                 // Nothing to do here.
                 Log::info('Revisionable: ' . $e);
-            }
+            }*/
 
             // if there was an issue
             // or, if it's a normal value

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -328,7 +328,8 @@ class Revision extends Eloquent
                 }
                 else
                 {
-                    throw New \RuntimeException("Primary Identifier Attribute not set in revisionable model '{$related_model}'");
+                    return "(Unknown)";
+                    //throw New \RuntimeException("Primary Identifier Attribute '".$primaryIdentifier."' not set in revisionable model '".get_class($related_model_object)."'");                    
                 }
             }
         }

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -19,6 +19,18 @@ class Revision extends Eloquent
     public $table = 'revisions';
 
     protected $revisionFormattedFields = array();
+    
+    const CREATE = 1;
+    const INSERT = 2;
+    const UPDATE = 3;
+    const DELETE = 4;
+    const REMOVE = 5;
+    
+    private $actions = array(self::CREATE=> 'created', 
+                                self::INSERT => 'inserted', 
+                                self::UPDATE => 'changed', 
+                                self::DELETE => 'deleted', 
+                                self::REMOVE => 'removed');    
 
     public function __construct(array $attributes = array())
     {
@@ -169,13 +181,13 @@ class Revision extends Eloquent
             // or, if it's a normal value
 
             // see if there's an available revision mutator
-            // see if there's an available revision mutator
             $revisionMutator = 'get' . studly_case($this->key) . 'RevisionAttribute';
             if (method_exists($main_model, $revisionMutator)) {
                 return $this->format($this->key, $main_model->$revisionMutator($this->$which_value));
             }
             else
             {
+                //else fallback to default eloquent mutator
                 $mutator = 'get' . studly_case($this->key) . 'Attribute';
                 if (method_exists($main_model, $mutator)) {
                     return $this->format($this->key, $main_model->$mutator($this->$which_value));
@@ -229,5 +241,52 @@ class Revision extends Eloquent
         } else {
             return $value;
         }
+    }
+    
+    /*
+     * Create a preformatted revision string
+     */
+    public function getRevisionString()
+    {
+        switch($this->action)
+        {
+            //Creating model
+            case self::CREATE:
+                
+                break;
+            //Inserting a value
+            case self::INSERT:
+                
+                break;
+            //Updating a value
+            case self::UPDATE:
+                
+                break;
+            //Deleting a value
+            case self::DELETE:
+                return $this->actions[$this->action]." (".$revisionClassName.") ID:".$this->revisionable_id;
+                break;
+            //Deleting a model
+            case self::REMOVE:
+                $related_model     = $this->revisionable_type;
+                $related_model     = new $related_model;
+                $revisionClassName = $related_model->getRevisionClassName() ? $related_model->getRevisionClassName() : $this->revisionable_type;
+                
+                return $this->actions[$this->action]." (".$revisionClassName.") ID:".$this->revisionable_id;
+            default:
+                return "created unknown revision";
+                break;
+        }
+    }
+    
+    /*
+     * Accessor
+     */
+    
+    public function className()
+    {
+        $related_model                   = $this->revisionable_type;
+        $related_model                   = new $related_model;
+        return $related_model->getRevisionClassName() ? $related_model->getRevisionClassName() : $this->revisionable_type;
     }
 }

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -169,17 +169,17 @@ class Revision extends Eloquent
             // or, if it's a normal value
 
             // see if there's an available revision mutator
-            $revisionmutator = 'get' . studly_case($this->key) . 'RevisionAttribute';
-            if (method_exists($item, $revisionmutator)) {
-                return $this->format($item->$mutator($this->key), $item->identifiableName());
+            // see if there's an available revision mutator
+            $revisionMutator = 'get' . studly_case($this->key) . 'RevisionAttribute';
+            if (method_exists($main_model, $revisionMutator)) {
+                return $this->format($this->key, $main_model->$revisionMutator($this->$which_value));
             }
             else
             {
-                // see if there's an available default eloquent mutator
                 $mutator = 'get' . studly_case($this->key) . 'Attribute';
-                if (method_exists($item, $mutator)) {
-                    return $this->format($item->$mutator($this->key), $item->identifiableName());
-                }                        
+                if (method_exists($main_model, $mutator)) {
+                    return $this->format($this->key, $main_model->$mutator($this->$which_value));
+                }
             }
 
         }

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -289,4 +289,77 @@ class Revision extends Eloquent
         $related_model                   = new $related_model;
         return $related_model->getRevisionClassName() ? $related_model->getRevisionClassName() : $this->revisionable_type;
     }
+    
+    /**
+     * Get Primary Identifier's Value
+     * 
+     * @param alternativeIdentifier string
+     * @return @string/@bool
+     **/
+    public function primaryIdentifierValue($alternativeIdentifier=false)
+    {
+        /*
+         * Get Primary Identifier from Revisionable model if alternative is not set
+         */
+        if($alternativeIdentifier === false)
+        {
+            $related_model = $this->revisionable_type;
+            $related_model = new $related_model;
+            $primaryIdentifier = $related_model->getRevisionPrimaryIdentifier();
+        }
+        else
+        {
+            $primaryIdentifier = $alternativeIdentifier;
+        }
+        
+        
+        //Verify if primary identifier attribute has been set in revisionable model
+        if($primaryIdentifier)
+        {
+            $related_model_object = $this->revisionable()->withTrashed()->first();
+            if(count($related_model_object))
+            {
+                /*
+                 * Check if attribute is present.
+                 */
+                if(isset($related_model_object->{$primaryIdentifier}))
+                {
+                    return $related_model_object->{$primaryIdentifier};
+                }
+                else
+                {
+                    throw New \RuntimeException("Primary Identifier Attribute not set in revisionable model '{$related_model}'");
+                }
+            }
+        }
+        
+        return false;
+    }
+    
+    /**
+     * Get Primary Identifier's Human Readable Name
+     * 
+     * @param string $alternativeIdentifier
+     * @return string/boolean
+     */
+    public function primaryIdentifierName($alternativeIdentifier=false)
+    {
+        if($alternativeIdentifier === false)
+        {
+            $related_model = $this->revisionable_type;
+            $related_model = new $related_model;
+            $primaryIdentifier = $related_model->getRevisionPrimaryIdentifier();
+        }
+        else
+        {
+            $primaryIdentifier = $alternativeIdentifier;
+        }
+        
+        if($primaryIdentifier)
+        {        
+            return $this->formatFieldName($primaryIdentifier);
+        }
+        
+        return false;
+    }
 }

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -142,13 +142,20 @@ class Revision extends Eloquent
                         return $this->format($this->key, $item->getRevisionUnknownString());
                     }
 
-
-                    // see if there's an available mutator
-                    $mutator = 'get' . studly_case($this->key) . 'Attribute';
-                    if (method_exists($item, $mutator)) {
+                    // see if there's an available revision mutator
+                    $revisionmutator = 'get' . studly_case($this->key) . 'RevisionAttribute';
+                    if (method_exists($item, $revisionmutator)) {
                         return $this->format($item->$mutator($this->key), $item->identifiableName());
                     }
-
+                    else
+                    {
+                        // see if there's an available default eloquent mutator
+                        $mutator = 'get' . studly_case($this->key) . 'Attribute';
+                        if (method_exists($item, $mutator)) {
+                            return $this->format($item->$mutator($this->key), $item->identifiableName());
+                        }                        
+                    }
+                    
                     return $this->format($this->key, $item->identifiableName());
                 }
 
@@ -161,9 +168,18 @@ class Revision extends Eloquent
             // if there was an issue
             // or, if it's a normal value
 
-            $mutator = 'get' . studly_case($this->key) . 'Attribute';
-            if (method_exists($main_model, $mutator)) {
-                return $this->format($this->key, $main_model->$mutator($this->$which_value));
+            // see if there's an available revision mutator
+            $revisionmutator = 'get' . studly_case($this->key) . 'RevisionAttribute';
+            if (method_exists($item, $revisionmutator)) {
+                return $this->format($item->$mutator($this->key), $item->identifiableName());
+            }
+            else
+            {
+                // see if there's an available default eloquent mutator
+                $mutator = 'get' . studly_case($this->key) . 'Attribute';
+                if (method_exists($item, $mutator)) {
+                    return $this->format($item->$mutator($this->key), $item->identifiableName());
+                }                        
             }
 
         }

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -206,7 +206,7 @@ class Revision extends Eloquent
      */
     public function userResponsible()
     {
-        if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')) {
+        if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry') || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')) {
             return $class::findUserById($this->user_id);
         } else {
             $user_model = Config::get('auth.model');

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -296,6 +296,11 @@ class Revisionable extends Eloquent
     {
         return $this->revisionClassName;
     }    
+    
+    public function getRevisionPrimaryIdentifier()
+    {
+        return $this->revisionPrimaryIdentifier;
+    }    
 
     /**
      * Identifiable Name

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -227,6 +227,11 @@ class Revisionable extends Eloquent
             } elseif (\Auth::check()) {
                 return \Auth::user()->getAuthIdentifier();
             }
+            else
+            {
+                //Use System Id when in Queue
+                return \Config::get('website.system_user_id');
+            }            
         } catch (\Exception $e) {
             return null;
         }

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -51,7 +51,6 @@ class Revisionable extends Eloquent
         });
 
         static::deleted(function ($model) {
-            $model->preSave();
             $model->postDelete();
         });
 

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -220,7 +220,7 @@ class Revisionable extends Eloquent
     {
 
         try {
-            if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry') && $class::check()) {
+            if ((class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry') || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')) && $class::check()) {
                 $user = $class::getUser();
 
                 return $user->id;

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -91,7 +91,7 @@ class Revisionable extends Eloquent
             unset($this->attributes['keepRevisionOf']);
 
             $this->dirtyData = $this->getDirty();
-            $this->updating = $this->exists;
+            $this->updating = $this->exists || (isset($this->keepCreateRevision) && $this->keepCreateRevision == true);
 
         }
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -231,6 +231,11 @@ trait RevisionableTrait
             } elseif (\Auth::check()) {
                 return \Auth::user()->getAuthIdentifier();
             }
+            else
+            {
+                //Use System Id when in Queue
+                return \Config::get('website.system_user_id');
+            }            
         } catch (\Exception $e) {
             return null;
         }

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -224,7 +224,7 @@ trait RevisionableTrait
     {
 
         try {
-            if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry') && $class::check()) {
+            if ((class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry') || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')) && $class::check()) {
                 $user = $class::getUser();
 
                 return $user->id;

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -51,7 +51,6 @@ trait RevisionableTrait
         });
 
         static::deleted(function ($model) {
-            $model->preSave();
             $model->postDelete();
         });
 
@@ -176,10 +175,10 @@ trait RevisionableTrait
             $revisions[] = array(
                 'revisionable_type' => get_class($this),
                 'revisionable_id' => $this->getKey(),
-                'key' => 'deleted_at',
+                'key' => null,
                 'old_value' => null,
                 'new_value' => null,
-                'action'    => Revision::DELETE,
+                'action'    => Revision::REMOVE,
                 'user_id' => $this->getUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
@@ -294,6 +293,11 @@ trait RevisionableTrait
     public function getRevisionClassName()
     {
         return $this->revisionClassName;
+    }
+    
+    public function getRevisionPrimaryIdentifier()
+    {
+        return $this->revisionPrimaryIdentifier;
     }
 
     /**

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -89,7 +89,7 @@ trait RevisionableTrait
             unset($this->attributes['keepRevisionOf']);
 
             $this->dirtyData = $this->getDirty();
-            $this->updating = $this->exists;
+            $this->updating = $this->exists || (isset($this->keepCreateRevision) && $this->keepCreateRevision == true);
 
         }
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -12,9 +12,10 @@ trait RevisionableTrait
 
     private $originalData;
     private $updatedData;
-    private $updating;
     private $dontKeep = array();
     private $doKeep = array();
+    
+
 
     /**
      * Keeps the list of values that have been updated
@@ -31,13 +32,22 @@ trait RevisionableTrait
     public static function boot()
     {
         parent::boot();
-
-        static::saving(function ($model) {
-            $model->preSave();
+        
+        static::creating(function ($model) {
+            $model->preUpdate();
+        });
+        
+        static::created(function ($model) {
+            $model->postCreate();
+            $model->postUpdate();
+        });
+        
+        static::updating(function ($model) {
+            $model->preUpdate();
         });
 
-        static::saved(function ($model) {
-            $model->postSave();
+        static::updated(function ($model) {
+            $model->postUpdate();
         });
 
         static::deleted(function ($model) {
@@ -57,7 +67,7 @@ trait RevisionableTrait
      *
      * @return bool
      */
-    public function preSave()
+    public function preUpdate()
     {
 
         if (!isset($this->revisionEnabled) || $this->revisionEnabled) {
@@ -89,51 +99,71 @@ trait RevisionableTrait
             unset($this->attributes['keepRevisionOf']);
 
             $this->dirtyData = $this->getDirty();
-            $this->updating = $this->exists || (isset($this->keepCreateRevision) && $this->keepCreateRevision == true);
 
         }
 
     }
 
-
     /**
-     * Called after a model is successfully saved.
+     * Called after a model is successfully updated.
      *
      * @return void
      */
-    public function postSave()
+    public function postUpdate()
     {
+        $changes_to_record = $this->changedRevisionableFields();
 
-        // check if the model already exists
-        if ((!isset($this->revisionEnabled) || $this->revisionEnabled) && $this->updating) {
-            // if it does, it means we're updating
+        $revisions = array();
 
-            $changes_to_record = $this->changedRevisionableFields();
+        foreach ($changes_to_record as $key => $change) {
+            $old_value = array_get($this->originalData, $key);
+            $new_value = $this->updatedData[$key];
+             
+            if($old_value == "" && $new_value == "")
+            {
+                //Both old val and new val is empty, nothing has changed at all
+                //Skip this iteration then
+                continue;
+            }
+            else
+            {
 
-            $revisions = array();
-
-            foreach ($changes_to_record as $key => $change) {
+                /*
+                 * Verify action
+                 */
+                // check if inserting
+                if($old_value == "" && $new_value != "")
+                {
+                    $action = Revision::INSERT;
+                }
+                //check if updating
+                if($old_value != "" && $new_value != "")
+                {
+                    $action = Revision::UPDATE;
+                }
+                //check if deleting
+                if($old_value != "" && $new_value == "")
+                {
+                    $action = Revision::DELETE;
+                }
 
                 $revisions[] = array(
                     'revisionable_type'     => get_class($this),
                     'revisionable_id'       => $this->getKey(),
                     'key'                   => $key,
-                    'old_value'             => array_get($this->originalData, $key),
-                    'new_value'             => $this->updatedData[$key],
+                    'old_value'             => $old_value,
+                    'new_value'             => $new_value,
+                    'action'                => $action,
                     'user_id'               => $this->getUserId(),
                     'created_at'            => new \DateTime(),
                     'updated_at'            => new \DateTime(),
                 );
-
             }
-
-            if (count($revisions) > 0) {
-                $revision = new Revision;
-                \DB::table($revision->getTable())->insert($revisions);
-            }
-
         }
 
+        if (!empty($revisions)) {
+            $this->saveRevision($revisions);
+        }
     }
 
     /**
@@ -142,20 +172,43 @@ trait RevisionableTrait
     public function postDelete()
     {
         if ((!isset($this->revisionEnabled) || $this->revisionEnabled)
-            && $this->softDelete
-            && $this->isRevisionable('deleted_at')) {
+            && $this->softDelete) {
             $revisions[] = array(
                 'revisionable_type' => get_class($this),
                 'revisionable_id' => $this->getKey(),
                 'key' => 'deleted_at',
                 'old_value' => null,
-                'new_value' => $this->deleted_at,
+                'new_value' => null,
+                'action'    => Revision::DELETE,
                 'user_id' => $this->getUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
             );
-            $revision = new \Venturecraft\Revisionable\Revision;
-            \DB::table($revision->getTable())->insert($revisions);
+            
+            $this->saveRevision($revisions);
+        }
+    }
+    
+    /*
+     * If saveCreateRevisions is enabled, save Creates of new model in the database
+     */
+    public function postCreate()
+    {
+        if((!isset($this->revisionEnabled) || $this->revisionEnabled) && (isset($this->saveCreateRevision) && $this->saveCreateRevision))
+        {
+            $revisions[] = array(
+                'revisionable_type' => get_class($this),
+                'revisionable_id' => $this->getKey(),
+                'key' => null,
+                'old_value' => null,
+                'new_value' => null,
+                'action'    => Revision::CREATE,
+                'user_id' => $this->getUserId(),
+                'created_at' => new \DateTime(),
+                'updated_at' => new \DateTime(),
+            );
+            
+            $this->saveRevision($revisions);            
         }
     }
 
@@ -237,6 +290,11 @@ trait RevisionableTrait
     {
         return $this->revisionFormattedFieldNames;
     }
+    
+    public function getRevisionClassName()
+    {
+        return $this->revisionClassName;
+    }
 
     /**
      * Identifiable Name
@@ -301,5 +359,18 @@ trait RevisionableTrait
             unset($donts);
         }
 
+    }
+    
+    /*
+     * Helper Function: saves revision data to revision table
+     * 
+     * @param array $revisions
+     * 
+     * @return bool;
+     */
+    private function saveRevision($revisions)
+    {
+        $revision = new \Venturecraft\Revisionable\Revision;
+        return \DB::table($revision->getTable())->insert($revisions);        
     }
 }

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -33,7 +33,13 @@ trait RevisionableTrait
     {
         parent::boot();
         
-        static::creating(function ($model) {
+        static::bootRevisionable();        
+
+    }
+    
+    public static function bootRevisionable()
+    {
+       static::creating(function ($model) {
             $model->preUpdate();
         });
         
@@ -52,8 +58,7 @@ trait RevisionableTrait
 
         static::deleted(function ($model) {
             $model->postDelete();
-        });
-
+        });        
     }
 
     public function revisionHistory()

--- a/src/migrations/2013_04_09_062329_create_revisions_table.php
+++ b/src/migrations/2013_04_09_062329_create_revisions_table.php
@@ -15,6 +15,7 @@ class CreateRevisionsTable extends Migration
 			$table->increments('id');
 			$table->string('revisionable_type');
 			$table->integer('revisionable_id');
+                        $table->tinyInteger('action');
 			$table->integer('user_id')->nullable();
 			$table->string('key');
 			$table->text('old_value')->nullable();


### PR DESCRIPTION
1) Changed model events in RevisionableTrait.php and Revisionable.php
2) Added column 'action' to migration file.
3) Added 'action' field to revision to determine type of revision. Type of revisions include: 
- CREATE (i.e sql INSERT table row)
- INSERT(i.e sql UPDATE table column - from old null value to new non-null value)
- UPDATE (i.e sql UPDATE table from old non-null value to new non-null value)
- DELETE (i.e sql UPDATE table column from old non-null value to new null value)
- REMOVE (i.e sql DELETE table row)

4) Set $saveCreateRevision attribute in eloquent model to save revisions with action 'CREATE' when set to TRUE.

5) Set $revisionClassName attribute in eloquent model to provide human-readable name for Eloquent models.

6) Removed attribute 'updating' since we are now using 'updating' model events to determine when a model is being updated.

Todo:

1) Provide pre-formatted string for getRevisionString()
2) Provide a way to merge revisions of revisionable model and its relationships (which are revisionable as well).
