### PR TITLE
Rework boot method to match Laravel 4.2 api.

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -24,15 +24,16 @@ trait RevisionableTrait
     protected $dirtyData = array();
 
     /**
-     * Create the event listeners for the saving and saved events
-     * This lets us save revisions whenever a save is made, no matter the
-     * http method.
+     * Boot the revisionable trait for a model.
      *
+     * Create the event listeners for the model events.
+     * This lets us save revisions whenever a save is made,
+     * no matter the http method.
+     *
+     * @return void
      */
-    public static function boot()
+    public static function bootRevisionableTrait()
     {
-        parent::boot();
-
         static::saving(function ($model) {
             $model->preSave();
         });
@@ -45,7 +46,24 @@ trait RevisionableTrait
             $model->preSave();
             $model->postDelete();
         });
+    }
 
+    /**
+     * The "booting" method of the model.
+     *
+     * @todo Remove this method if minimum version of Laravel is 4.2.
+     *
+     * @return void
+     */
+    public static function boot()
+    {
+        parent::boot();
+
+        // This allows versions of Laravel before 4.2 to use the
+        // trait while still having boot methods in the model class.
+        if (! method_exists(get_called_class(), 'bootTraits')) {
+            static::bootRevisionableTrait();
+        }
     }
 
     public function revisionHistory()


### PR DESCRIPTION
Fake the Laravel 4.2 bootable traits API.

Fixes https://github.com/VentureCraft/revisionable/issues/83.
Also see https://github.com/VentureCraft/revisionable/pull/78.