### PR TITLE
added method to get all revisions for a class

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -110,6 +110,19 @@ class Article extends Eloquent {
 }
 ```
 
+You can also disable revisioning after X many revisions have been made by setting `$historyLimit` to the number of revisions you want to keep before stopping revisions.
+
+```php
+namespace MyApp\Models;
+
+class Article extends Eloquent {
+    use Venturecraft\Revisionable\RevisionableTrait;
+
+    protected $revisionEnabled = true;
+    protected $historyLimit = 500; //Stop tracking revisions after 500 changes have been made.
+}
+```
+
 ### Storing soft deletes
 
 By default, if your model supports soft deletes, revisionable will store this and any restores as updates on the model.

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -179,7 +179,7 @@ class Revision extends Eloquent
     {
         if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
                 || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')) {
-            return $class::findUserById($this->revisionable_id);
+            return $class::findUserById($this->user_id);
         } else {
             $user_model = app('config')->get('auth.model');
 

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -179,12 +179,22 @@ class Revision extends Eloquent
     {
         if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
                 || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')) {
-            return $class::findUserById($this->user_id);
+            return $class::findUserById($this->revisionable_id);
         } else {
             $user_model = app('config')->get('auth.model');
 
             return $user_model::find($this->user_id);
         }
+    }
+
+
+    /**
+     * Returns the object we have the history of
+     * @return Object or false
+     */
+    public function historyOf()
+    {
+        return class_exists($class = $this->revisionable_type) ? $class::find($this->revisionable_id) : false;
     }
 
     /*

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -194,7 +194,13 @@ class Revision extends Eloquent
      */
     public function historyOf()
     {
-        return class_exists($class = $this->revisionable_type) ? $class::find($this->revisionable_id) : false;
+        if(class_exists($class = $this->revisionable_type))
+        {
+            $dd = $class::find($this->revisionable_id);
+            dd($dd);
+            return $class::find($this->revisionable_id);
+        }
+        return false;
     }
 
     /*

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -57,6 +57,7 @@ trait RevisionableTrait
      * Generates a list of the last $limit revisions made to any objects of the class it is being called from.
      *
      * @param int $limit
+     * @param string $order
      * @return mixed
      */
     public static function classRevisionHistory($limit=100,$order='desc')

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -54,6 +54,16 @@ trait RevisionableTrait
     }
 
     /**
+     * Generates a list of the last $limit revisions made to any objects of the class it is being called from.
+     *
+     * @param int $limit
+     * @return mixed
+     */
+    public static function classRevisionHistory($limit=100)
+    {
+        return \Venturecraft\Revisionable\Revision::where('revisionable_type',get_called_class())->orderBy('updated_at')->limit($limit)->get();
+    }
+    /**
      * Invoked before a model is saved. Return false to abort the operation.
      *
      * @return bool

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -59,9 +59,9 @@ trait RevisionableTrait
      * @param int $limit
      * @return mixed
      */
-    public static function classRevisionHistory($limit=100)
+    public static function classRevisionHistory($limit=100,$order='desc')
     {
-        return \Venturecraft\Revisionable\Revision::where('revisionable_type',get_called_class())->orderBy('updated_at')->limit($limit)->get();
+        return \Venturecraft\Revisionable\Revision::where('revisionable_type',get_called_class())->orderBy('updated_at',$order)->limit($limit)->get();
     }
     /**
      * Invoked before a model is saved. Return false to abort the operation.

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -71,13 +71,8 @@ trait RevisionableTrait
      */
     public function preSave()
     {
-        if (isset($this->historyLimit) && $this->revisionHistory()->count() >= $this->historyLimit){
-            $LimitReached=true;
-        }else{
-            $LimitReached=false;
-        }
 
-        if ((!isset($this->revisionEnabled) || $this->revisionEnabled) && !$LimitReached) {
+        if (!isset($this->revisionEnabled) || $this->revisionEnabled) {
             // if there's no revisionEnabled. Or if there is, if it's true
 
             $this->originalData = $this->original;
@@ -120,9 +115,14 @@ trait RevisionableTrait
      */
     public function postSave()
     {
+        if (isset($this->historyLimit) && $this->revisionHistory()->count() >= $this->historyLimit){
+            $LimitReached=true;
+        }else{
+            $LimitReached=false;
+        }
 
         // check if the model already exists
-        if ((!isset($this->revisionEnabled) || $this->revisionEnabled) && $this->updating) {
+        if (((!isset($this->revisionEnabled) || $this->revisionEnabled) && $this->updating) && !$LimitReached) {
             // if it does, it means we're updating
 
             $changes_to_record = $this->changedRevisionableFields();

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -71,8 +71,13 @@ trait RevisionableTrait
      */
     public function preSave()
     {
+        if (isset($this->historyLimit) && $this->revisionHistory()->count() >= $this->historyLimit){
+            $LimitReached=true;
+        }else{
+            $LimitReached=false;
+        }
 
-        if (!isset($this->revisionEnabled) || $this->revisionEnabled) {
+        if ((!isset($this->revisionEnabled) || $this->revisionEnabled) && !$LimitReached) {
             // if there's no revisionEnabled. Or if there is, if it's true
 
             $this->originalData = $this->original;


### PR DESCRIPTION
Created a way to get all revisions from an Object.

This is useful for displaying the last $limit User/Post/Blog/Etc changes in an admin panel.