### PR TITLE
Added functionality to track model creations

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ class Article extends Eloquent {
     protected $historyLimit = 500; //Stop tracking revisions after 500 changes have been made.
 }
 ```
-In order to maintain a limit on history, but instead of stopping tracking revisions if you want to remove old revisions, you can accomodate that feature by setting `$revisionCleanup`. 
+In order to maintain a limit on history, but instead of stopping tracking revisions if you want to remove old revisions, you can accomodate that feature by setting `$revisionCleanup`.
 
 ```php
 namespace MyApp\Models;
@@ -151,6 +151,16 @@ You can choose to ignore deletes and restores by adding `deleted_at` to your `$d
 To better format the output for `deleted_at` entries, you can use the `isEmpty` formatter (see <a href="#format-output">Format output</a> for an example of this.)
 
 <a name="control"></a>
+
+### Storing creations
+By default the creation of a new model is not stored as a revision.
+Only subsequent changes to a model is stored.
+
+If you want to store the creation as a revision you can override this behavior by setting `revisionCreationsEnabled` to `true` by adding the following to your model:
+```php
+protected $revisionCreationsEnabled = true;
+```
+
 ## More control
 
 No doubt, there'll be cases where you don't want to store a revision history only for certain fields of the model, this is supported in two different ways. In your model you can either specifiy which fields you explicitly want to track and all other fields are ignored:
@@ -249,6 +259,17 @@ The above would be the result from this:
 ```php
 @foreach($account->revisionHistory as $history )
     <li>{{ $history->userResponsible()->first_name }} changed {{ $history->fieldName() }} from {{ $history->oldValue() }} to {{ $history->newValue() }}</li>
+@endforeach
+```
+
+If you have enabled revisions of creations as well you can display it like this:
+```php
+@foreach($resource->revisionHistory as $history)
+  @if($history->key == 'created_at' && !$history->old_value)
+    <li>{{ $history->userResponsible()->first_name }} created this resource at {{ $history->newValue() }}</li>
+  @else
+    <li>{{ $history->userResponsible()->first_name }} changed {{ $history->fieldName() }} from {{ $history->oldValue() }} to {{ $history->newValue() }}</li>
+  @endif
 @endforeach
 ```
 

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -164,25 +164,32 @@ class Revisionable extends Eloquent
     */
     public function postCreate()
     {
-      if ((!isset($this->revisionEnabled) || $this->revisionEnabled))
-      {
-          $revisions[] = array(
-              'revisionable_type' => get_class($this),
-              'revisionable_id' => $this->getKey(),
-              'key' => 'created_at',
-              'old_value' => null,
-              'new_value' => $this->created_at,
-              'user_id' => $this->getUserId(),
-              'created_at' => new \DateTime(),
-              'updated_at' => new \DateTime(),
-          );
 
-          $revision = new Revision;
-          \DB::table($revision->getTable())->insert($revisions);
+        // Check if we should store creations in our revision history
+        // Set this value to true in your model if you want to
+        if(empty($this->revisionCreationsEnabled))
+        {
+            // We should not store creations.
+            return false;
+        }
 
-      }
+        if ((!isset($this->revisionEnabled) || $this->revisionEnabled))
+        {
+            $revisions[] = array(
+                'revisionable_type' => get_class($this),
+                'revisionable_id' => $this->getKey(),
+                'key' => 'created_at',
+                'old_value' => null,
+                'new_value' => $this->created_at,
+                'user_id' => $this->getUserId(),
+                'created_at' => new \DateTime(),
+                'updated_at' => new \DateTime(),
+            );
 
+            $revision = new Revision;
+            \DB::table($revision->getTable())->insert($revisions);
 
+        }
     }
 
     /**

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -64,6 +64,10 @@ class Revisionable extends Eloquent
             $model->postSave();
         });
 
+        static::created(function($model){
+            $model->postCreate();
+        });
+
         static::deleted(function ($model) {
             $model->preSave();
             $model->postDelete();
@@ -153,6 +157,32 @@ class Revisionable extends Eloquent
                 \DB::table($revision->getTable())->insert($revisions);
             }
         }
+    }
+
+    /**
+    * Called after record successfully created
+    */
+    public function postCreate()
+    {
+      if ((!isset($this->revisionEnabled) || $this->revisionEnabled))
+      {
+          $revisions[] = array(
+              'revisionable_type' => get_class($this),
+              'revisionable_id' => $this->getKey(),
+              'key' => 'created_at',
+              'old_value' => null,
+              'new_value' => $this->created_at,
+              'user_id' => $this->getUserId(),
+              'created_at' => new \DateTime(),
+              'updated_at' => new \DateTime(),
+          );
+
+          $revision = new Revision;
+          \DB::table($revision->getTable())->insert($revisions);
+
+      }
+
+
     }
 
     /**

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -205,23 +205,32 @@ trait RevisionableTrait
     */
     public function postCreate()
     {
-      if ((!isset($this->revisionEnabled) || $this->revisionEnabled))
-      {
-          $revisions[] = array(
-              'revisionable_type' => get_class($this),
-              'revisionable_id' => $this->getKey(),
-              'key' => 'created_at',
-              'old_value' => null,
-              'new_value' => $this->created_at,
-              'user_id' => $this->getUserId(),
-              'created_at' => new \DateTime(),
-              'updated_at' => new \DateTime(),
-          );
 
-          $revision = new Revision;
-          \DB::table($revision->getTable())->insert($revisions);
+        // Check if we should store creations in our revision history
+        // Set this value to true in your model if you want to
+        if(empty($this->revisionCreationsEnabled))
+        {
+            // We should not store creations.
+            return false;
+        }
 
-      }
+        if ((!isset($this->revisionEnabled) || $this->revisionEnabled))
+        {
+            $revisions[] = array(
+                'revisionable_type' => get_class($this),
+                'revisionable_id' => $this->getKey(),
+                'key' => 'created_at',
+                'old_value' => null,
+                'new_value' => $this->created_at,
+                'user_id' => $this->getUserId(),
+                'created_at' => new \DateTime(),
+                'updated_at' => new \DateTime(),
+            );
+
+            $revision = new Revision;
+            \DB::table($revision->getTable())->insert($revisions);
+
+        }
 
 
     }

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -75,6 +75,10 @@ trait RevisionableTrait
             $model->postSave();
         });
 
+        static::created(function($model){
+            $model->postCreate();
+        });
+
         static::deleted(function ($model) {
             $model->preSave();
             $model->postDelete();
@@ -103,10 +107,10 @@ trait RevisionableTrait
     }
 
     /**
-     * Invoked before a model is saved. Return false to abort the operation.
-     *
-     * @return bool
-     */
+    * Invoked before a model is saved. Return false to abort the operation.
+    *
+    * @return bool
+    */
     public function preSave()
     {
         if (!isset($this->revisionEnabled) || $this->revisionEnabled) {
@@ -194,6 +198,32 @@ trait RevisionableTrait
                 \DB::table($revision->getTable())->insert($revisions);
             }
         }
+    }
+
+    /**
+    * Called after record successfully created
+    */
+    public function postCreate()
+    {
+      if ((!isset($this->revisionEnabled) || $this->revisionEnabled))
+      {
+          $revisions[] = array(
+              'revisionable_type' => get_class($this),
+              'revisionable_id' => $this->getKey(),
+              'key' => 'created_at',
+              'old_value' => null,
+              'new_value' => $this->created_at,
+              'user_id' => $this->getUserId(),
+              'created_at' => new \DateTime(),
+              'updated_at' => new \DateTime(),
+          );
+
+          $revision = new Revision;
+          \DB::table($revision->getTable())->insert($revisions);
+
+      }
+
+
     }
 
     /**


### PR DESCRIPTION
Ability to also track model creations in revisions.

It can be displayed like this:
```
@foreach($user->revisionHistory as $history)
  @if($history->key == 'created_at' && !$history->old_value)
    <li>Resource was created at {{ $history->new_value }}</li>
  @else
    <li>{{ ucfirst($history->key) }} changed from {{ $history->old_value }} to {{ $history->new_value }}</li>
  @endif
@endforeach
```