### PR TITLE
Fixed typographical error, changed accomodate to accommodate in README.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ class Article extends Eloquent {
     protected $historyLimit = 500; //Stop tracking revisions after 500 changes have been made.
 }
 ```
-In order to maintain a limit on history, but instead of stopping tracking revisions if you want to remove old revisions, you can accomodate that feature by setting `$revisionCleanup`.
+In order to maintain a limit on history, but instead of stopping tracking revisions if you want to remove old revisions, you can accommodate that feature by setting `$revisionCleanup`.
 
 ```php
 namespace MyApp\Models;


### PR DESCRIPTION
VentureCraft, I've corrected a typographical error in the documentation of the [revisionable](https://github.com/VentureCraft/revisionable) project. You should be able to merge this pull request automatically. However, if this was intentional or you enjoy living in linguistic squalor please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.