### PR TITLE
Use Artisan's publish features to make copying migrations an easier process.

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -41,15 +41,18 @@ Run composer update to download the package
 php composer.phar update
 ```
 
-Finally, you'll also need to run migration on the package
+After updating composer, add the service provider to the `providers` array in `config/app.php`
+
+```php
+Venturecraft\Revisionable\RevisionableServiceProvider::class,
+```
+
+Finally, publish the migrations and then migrate.
 
 ```
-php artisan migrate --package=venturecraft/revisionable
+php artisan vendor:publish --provider="Venturecraft\Revisionable\RevisionableServiceProvider"
+php artisan migrate
 ```
-
-> If you're going to be migrating up and down completely a lot (using `migrate:refresh`), one thing you can do instead is to copy the migration file from the package to your `app/database` folder, and change the classname from `CreateRevisionsTable` to something like `CreateRevisionTable` (without the 's', otherwise you'll get an error saying there's a duplicate class)
-
-> `cp vendor/venturecraft/revisionable/src/migrations/2013_04_09_062329_create_revisions_table.php app/database/migrations/`
 
 ## Docs
 

--- a/src/Venturecraft/Revisionable/RevisionableServiceProvider.php
+++ b/src/Venturecraft/Revisionable/RevisionableServiceProvider.php
@@ -12,4 +12,9 @@ class RevisionableServiceProvider extends ServiceProvider
 			__DIR__ . '/../../migrations/' => database_path('/migrations')
 		], 'migrations');
 	}
+
+	public function register()
+	{
+		
+	}
 }

--- a/src/Venturecraft/Revisionable/RevisionableServiceProvider.php
+++ b/src/Venturecraft/Revisionable/RevisionableServiceProvider.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Venturecraft\Revisionable;
+
+use Illuminate\Support\ServiceProvider;
+
+class RevisionableServiceProvider extends ServiceProvider
+{
+	public function boot()
+	{
+		$this->publishes([
+			__DIR__ . '/../../migrations/' => database_path('/migrations')
+		], 'migrations');
+	}
+}


### PR DESCRIPTION
Rather than copying and pasting the migration file (and therefore having to worry about class names clashing), I updated the package to include a service provider that registers the migration as a publishable asset and updated the readme to include instructions on how to register the service provider and publish the migration files.

I hate to introduce more steps into the installation process of the package, but most other Laravel packages have a service provider so it's almost an expectation from me that when I'm installing a package, I'm going to need to configure a service provider. I like to consider it forward thinking, because one day this package might need to utilize a service provider, and it's better to tell them to configure the service provider now rather than in the future.

I'd also like to emphasize that if users opt not to use the service provider, it won't break the functionality of the package. Therefore those updating to the latest code won't need to figure out why their site has stopped working (and also negating the need for a major version bump).