### PR TITLE
Cast the revisionable ID to a string to overcome issues with Uuids

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -23,6 +23,13 @@ class Revision extends Eloquent
     /**
      * @var array
      */
+    protected $casts = array(
+        'revisionable_id' => 'string';
+    );
+
+    /**
+     * @var array
+     */
     protected $revisionFormattedFields = array();
 
     /**


### PR DESCRIPTION
We're currently using Revisionable in a project that has Uuids for primary keys. Without this change, the IDs keep getting cast to integers, which don't work