### PR TITLE
Added support for SleepingOwl Admin authentication

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -266,7 +266,8 @@ trait RevisionableTrait
     public function getUserId()
     {
         try {
-            if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
+            if (class_exists($class = '\SleepingOwl\AdminAuth\Facades\AdminAuth')
+                || class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
                 || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')
             ) {
                 return ($class::check()) ? $class::getUser()->id : null;


### PR DESCRIPTION
Because SleepingOwl Admin uses its own authentication method, you can't use the stock Auth.