### PR TITLE
Support for Laravel 5.2 in userResponsible() call

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -194,6 +194,7 @@ class Revision extends Eloquent
      */
     public function userResponsible()
     {
+        if (empty($this->user_id)) { return false; }
         if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
             || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')
         ) {
@@ -201,6 +202,15 @@ class Revision extends Eloquent
         } else {
             $user_model = app('config')->get('auth.model');
 
+            if (empty($user_model)) {
+                $user_model = app('config')->get('auth.providers.users.model');
+                if (empty($user_model)) {
+                    return false;
+                }
+            }
+            if (!class_exists($user_model)) {
+                return false;
+            }
             return $user_model::find($this->user_id);
         }
     }


### PR DESCRIPTION
(and backward compatible). Also gracefully return false if no class found/doesn't exist, vs. throwing a PHP error about class name

Laravel 5.2 release/upgrade notes have user replace config/auth.php which points to a different location for model.  This causes Revisionable to blow up when calling userResponsible()
See: https://laravel.com/docs/5.2/upgrade#upgrade-5.2.0 + https://github.com/laravel/laravel/blob/master/config/auth.php

Also will fail nicely if the Model can't be found/doesn't found, and returns false early on if no user_id vs. checking classes (nice for the many records where no user_id is provided)