### PR TITLE
Change function name from getUserId to getSystemUserId

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -181,7 +181,7 @@ trait RevisionableTrait
                     'key' => $key,
                     'old_value' => array_get($this->originalData, $key),
                     'new_value' => $this->updatedData[$key],
-                    'user_id' => $this->getUserId(),
+                    'user_id' => $this->getSystemUserId(),
                     'created_at' => new \DateTime(),
                     'updated_at' => new \DateTime(),
                 );
@@ -222,7 +222,7 @@ trait RevisionableTrait
                 'key' => 'created_at',
                 'old_value' => null,
                 'new_value' => $this->created_at,
-                'user_id' => $this->getUserId(),
+                'user_id' => $this->getSystemUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
             );
@@ -250,7 +250,7 @@ trait RevisionableTrait
                 'key' => 'deleted_at',
                 'old_value' => null,
                 'new_value' => $this->deleted_at,
-                'user_id' => $this->getUserId(),
+                'user_id' => $this->getSystemUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
             );
@@ -263,7 +263,7 @@ trait RevisionableTrait
      * Attempt to find the user id of the currently logged in user
      * Supports Cartalyst Sentry/Sentinel based authentication, as well as stock Auth
      **/
-    public function getUserId()
+    public function getSystemUserId()
     {
         try {
             if (class_exists($class = '\SleepingOwl\AdminAuth\Facades\AdminAuth')


### PR DESCRIPTION
To avoid clash with the same function name in Sentinel User Model. Fix for <a href="https://github.com/VentureCraft/revisionable/issues/198">Issue#198</a>