### PR TITLE
Update FieldFormatter to handle empty dates

### DIFF
--- a/src/Venturecraft/Revisionable/FieldFormatter.php
+++ b/src/Venturecraft/Revisionable/FieldFormatter.php
@@ -109,6 +109,10 @@ class FieldFormatter
      */
     public static function datetime($value, $format = 'Y-m-d H:i:s')
     {
+        if (empty($value)) {
+            return 'Null';
+        }
+        
         $datetime = new \DateTime($value);
 
         return $datetime->format($format);


### PR DESCRIPTION
The **datetime** FieldFormatter returns the current time if null passed in. I know this is the default behaviour of [DateTime](http://php.net/manual/en/datetime.construct.php) but I was wondering if it is possible to change to the following?

This is the current behaviour
```
User changed Date from 08-02-2016 to 16-12-2016
User changed Date from 16-12-2016 to 08-02-2016
```

Updated behaviour
```
User changed Date from Null to 16-12-2016
User changed Date from 16-12-2016 to Null
```

Let me know,
Thanks