### PR TITLE
Update FieldFormatter to handle empty dates

### DIFF
--- a/src/Venturecraft/Revisionable/FieldFormatter.php
+++ b/src/Venturecraft/Revisionable/FieldFormatter.php
@@ -109,6 +109,10 @@ class FieldFormatter
      */
     public static function datetime($value, $format = 'Y-m-d H:i:s')
     {
+        if (empty($value)) {
+            return null;    
+        }
+        
         $datetime = new \DateTime($value);
 
         return $datetime->format($format);


### PR DESCRIPTION
The **datetime** FieldFormatter returns the current time if null passed in. The following changes this to return null as value.

Thanks