### PR TITLE
create config and fix migration

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -19,7 +19,7 @@ Revisionable is a laravel package that allows you to keep a revision history for
 
 ## Working with 3rd party Auth / Eloquent extensions
 
-Revisionable has support for Auth powered by
+Revisionable has support for Auth. You can manually set the auth model to revisionable config on user model.
 * [**Sentry by Cartalyst**](https://cartalyst.com/manual/sentry).
 * [**Sentinel by Cartalyst**](https://cartalyst.com/manual/sentinel).
 
@@ -44,12 +44,8 @@ php composer.phar update
 Finally, you'll also need to run migration on the package
 
 ```
-php artisan migrate --package=venturecraft/revisionable
+php artisan vendor:publish --provider="Vendor\venturecraft\revisionable\RevisionableServiceProvider"
 ```
-
-> If you're going to be migrating up and down completely a lot (using `migrate:refresh`), one thing you can do instead is to copy the migration file from the package to your `app/database` folder, and change the classname from `CreateRevisionsTable` to something like `CreateRevisionTable` (without the 's', otherwise you'll get an error saying there's a duplicate class)
-
-> `cp vendor/venturecraft/revisionable/src/migrations/2013_04_09_062329_create_revisions_table.php app/database/migrations/`
 
 ## Docs
 

--- a/src/Venturecraft/Revisionable/FieldFormatter.php
+++ b/src/Venturecraft/Revisionable/FieldFormatter.php
@@ -1,6 +1,4 @@
-<?php
-
-namespace Venturecraft\Revisionable;
+<?php namespace Venturecraft\Revisionable;
 
 /**
  * FieldFormatter.
@@ -98,7 +96,7 @@ class FieldFormatter
 
         return sprintf($format, $value);
     }
-    
+
     /**
      * Format the datetime
      *
@@ -110,9 +108,9 @@ class FieldFormatter
     public static function datetime($value, $format = 'Y-m-d H:i:s')
     {
         if (empty($value)) {
-            return null;    
+            return null;
         }
-        
+
         $datetime = new \DateTime($value);
 
         return $datetime->format($format);

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -64,7 +64,7 @@ class Revisionable extends Eloquent
             $model->postSave();
         });
 
-        static::created(function($model){
+        static::created(function ($model) {
             $model->postCreate();
         });
 
@@ -79,7 +79,7 @@ class Revisionable extends Eloquent
      */
     public function revisionHistory()
     {
-        return $this->morphMany('\Venturecraft\Revisionable\Revision', 'revisionable');
+        return $this->morphMany(config('revisionable.revision.model'), 'revisionable');
     }
 
     /**
@@ -93,12 +93,12 @@ class Revisionable extends Eloquent
             // if there's no revisionEnabled. Or if there is, if it's true
 
             $this->originalData = $this->original;
-            $this->updatedData  = $this->attributes;
+            $this->updatedData = $this->attributes;
 
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-                if (gettype($val) == 'object' && ! method_exists($val, '__toString')) {
+                if (gettype($val) == 'object' && !method_exists($val, '__toString')) {
                     unset($this->originalData[$key]);
                     unset($this->updatedData[$key]);
                 }
@@ -107,12 +107,12 @@ class Revisionable extends Eloquent
             // the below is ugly, for sure, but it's required so we can save the standard model
             // then use the keep / dontkeep values for later, in the isRevisionable method
             $this->dontKeep = isset($this->dontKeepRevisionOf) ?
-                $this->dontKeepRevisionOf + $this->dontKeep
-                : $this->dontKeep;
+            $this->dontKeepRevisionOf + $this->dontKeep
+            : $this->dontKeep;
 
             $this->doKeep = isset($this->keepRevisionOf) ?
-                $this->keepRevisionOf + $this->doKeep
-                : $this->doKeep;
+            $this->keepRevisionOf + $this->doKeep
+            : $this->doKeep;
 
             unset($this->attributes['dontKeepRevisionOf']);
             unset($this->attributes['keepRevisionOf']);
@@ -121,7 +121,6 @@ class Revisionable extends Eloquent
             $this->updating = $this->exists;
         }
     }
-
 
     /**
      * Called after a model is successfully saved.
@@ -141,14 +140,14 @@ class Revisionable extends Eloquent
 
             foreach ($changes_to_record as $key => $change) {
                 $revisions[] = array(
-                    'revisionable_type'     => get_class($this),
-                    'revisionable_id'       => $this->getKey(),
-                    'key'                   => $key,
-                    'old_value'             => array_get($this->originalData, $key),
-                    'new_value'             => $this->updatedData[$key],
-                    'user_id'               => $this->getUserId(),
-                    'created_at'            => new \DateTime(),
-                    'updated_at'            => new \DateTime(),
+                    'revisionable_type' => get_class($this),
+                    'revisionable_id' => $this->getKey(),
+                    'key' => $key,
+                    'old_value' => array_get($this->originalData, $key),
+                    'new_value' => $this->updatedData[$key],
+                    'user_id' => $this->getUserId(),
+                    'created_at' => new \DateTime(),
+                    'updated_at' => new \DateTime(),
                 );
             }
 
@@ -160,21 +159,19 @@ class Revisionable extends Eloquent
     }
 
     /**
-    * Called after record successfully created
-    */
+     * Called after record successfully created
+     */
     public function postCreate()
     {
 
         // Check if we should store creations in our revision history
         // Set this value to true in your model if you want to
-        if(empty($this->revisionCreationsEnabled))
-        {
+        if (empty($this->revisionCreationsEnabled)) {
             // We should not store creations.
             return false;
         }
 
-        if ((!isset($this->revisionEnabled) || $this->revisionEnabled))
-        {
+        if ((!isset($this->revisionEnabled) || $this->revisionEnabled)) {
             $revisions[] = array(
                 'revisionable_type' => get_class($this),
                 'revisionable_id' => $this->getKey(),
@@ -222,8 +219,7 @@ class Revisionable extends Eloquent
     private function getUserId()
     {
         try {
-            if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
-                    || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')) {
+            if (class_exists($class = config('revisionable.user.model'))) {
                 return ($class::check()) ? $class::getUser()->id : null;
             } elseif (\Auth::check()) {
                 return \Auth::user()->getAuthIdentifier();
@@ -346,7 +342,7 @@ class Revisionable extends Eloquent
      */
     public function getRevisionNullString()
     {
-        return isset($this->revisionNullString)?$this->revisionNullString:'nothing';
+        return isset($this->revisionNullString) ? $this->revisionNullString : 'nothing';
     }
 
     /**
@@ -359,7 +355,7 @@ class Revisionable extends Eloquent
      */
     public function getRevisionUnknownString()
     {
-        return isset($this->revisionUnknownString)?$this->revisionUnknownString:'unknown';
+        return isset($this->revisionUnknownString) ? $this->revisionUnknownString : 'unknown';
     }
 
     /**

--- a/src/Venturecraft/Revisionable/RevisionableServiceProvider.php
+++ b/src/Venturecraft/Revisionable/RevisionableServiceProvider.php
@@ -1,0 +1,24 @@
+<?php namespace Venturecraft\Revisionable;
+
+use Illuminate\Support\ServiceProvider;
+
+class RevisionableServiceProvider extends ServiceProvider
+{
+    protected $defer = false;
+
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__ . '/../../config/revisionable.php' => config_path('revisionable.php'),
+        ], 'config');
+
+        $this->publishes([
+            __DIR__ . '/../../migrations/' => database_path('migrations'),
+        ], 'migrations');
+    }
+
+    public function register()
+    {
+
+    }
+}

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -75,7 +75,7 @@ trait RevisionableTrait
             $model->postSave();
         });
 
-        static::created(function($model){
+        static::created(function ($model) {
             $model->postCreate();
         });
 
@@ -90,7 +90,17 @@ trait RevisionableTrait
      */
     public function revisionHistory()
     {
-        return $this->morphMany('\Venturecraft\Revisionable\Revision', 'revisionable');
+        return $this->morphMany(config('revisionable.revision.model'), 'revisionable');
+    }
+
+    /**
+     * @param int $limit
+     * @return mixed
+     */
+
+    public function getRevisionHistory($limit = 10)
+    {
+        return $this->revisionHistory->take($limit);
     }
 
     /**
@@ -102,15 +112,16 @@ trait RevisionableTrait
      */
     public static function classRevisionHistory($limit = 100, $order = 'desc')
     {
-        return \Venturecraft\Revisionable\Revision::where('revisionable_type', get_called_class())
+        $class = config('revisionable.revision.model');
+        return $class::where('revisionable_type', get_called_class())
             ->orderBy('updated_at', $order)->limit($limit)->get();
     }
 
     /**
-    * Invoked before a model is saved. Return false to abort the operation.
-    *
-    * @return bool
-    */
+     * Invoked before a model is saved. Return false to abort the operation.
+     *
+     * @return bool
+     */
     public function preSave()
     {
         if (!isset($this->revisionEnabled) || $this->revisionEnabled) {
@@ -132,12 +143,12 @@ trait RevisionableTrait
             // the below is ugly, for sure, but it's required so we can save the standard model
             // then use the keep / dontkeep values for later, in the isRevisionable method
             $this->dontKeep = isset($this->dontKeepRevisionOf) ?
-                $this->dontKeepRevisionOf + $this->dontKeep
-                : $this->dontKeep;
+            $this->dontKeepRevisionOf + $this->dontKeep
+            : $this->dontKeep;
 
             $this->doKeep = isset($this->keepRevisionOf) ?
-                $this->keepRevisionOf + $this->doKeep
-                : $this->doKeep;
+            $this->keepRevisionOf + $this->doKeep
+            : $this->doKeep;
 
             unset($this->attributes['dontKeepRevisionOf']);
             unset($this->attributes['keepRevisionOf']);
@@ -146,7 +157,6 @@ trait RevisionableTrait
             $this->updating = $this->exists;
         }
     }
-
 
     /**
      * Called after a model is successfully saved.
@@ -160,10 +170,10 @@ trait RevisionableTrait
         } else {
             $LimitReached = false;
         }
-        if (isset($this->revisionCleanup)){
-            $RevisionCleanup=$this->revisionCleanup;
-        }else{
-            $RevisionCleanup=false;
+        if (isset($this->revisionCleanup)) {
+            $RevisionCleanup = $this->revisionCleanup;
+        } else {
+            $RevisionCleanup = false;
         }
 
         // check if the model already exists
@@ -188,9 +198,9 @@ trait RevisionableTrait
             }
 
             if (count($revisions) > 0) {
-                if($LimitReached && $RevisionCleanup){
-                    $toDelete = $this->revisionHistory()->orderBy('id','asc')->limit(count($revisions))->get();
-                    foreach($toDelete as $delete){
+                if ($LimitReached && $RevisionCleanup) {
+                    $toDelete = $this->revisionHistory()->orderBy('id', 'asc')->limit(count($revisions))->get();
+                    foreach ($toDelete as $delete) {
                         $delete->delete();
                     }
                 }
@@ -201,21 +211,19 @@ trait RevisionableTrait
     }
 
     /**
-    * Called after record successfully created
-    */
+     * Called after record successfully created
+     */
     public function postCreate()
     {
 
         // Check if we should store creations in our revision history
         // Set this value to true in your model if you want to
-        if(empty($this->revisionCreationsEnabled))
-        {
+        if (empty($this->revisionCreationsEnabled)) {
             // We should not store creations.
             return false;
         }
 
-        if ((!isset($this->revisionEnabled) || $this->revisionEnabled))
-        {
+        if ((!isset($this->revisionEnabled) || $this->revisionEnabled)) {
             $revisions[] = array(
                 'revisionable_type' => get_class($this),
                 'revisionable_id' => $this->getKey(),
@@ -231,7 +239,6 @@ trait RevisionableTrait
             \DB::table($revision->getTable())->insert($revisions);
 
         }
-
 
     }
 
@@ -254,7 +261,8 @@ trait RevisionableTrait
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
             );
-            $revision = new \Venturecraft\Revisionable\Revision;
+            $class = config('revisionable.revision.model');
+            $revision = new $class;
             \DB::table($revision->getTable())->insert($revisions);
         }
     }
@@ -266,9 +274,7 @@ trait RevisionableTrait
     public function getUserId()
     {
         try {
-            if (class_exists($class = '\SleepingOwl\AdminAuth\Facades\AdminAuth')
-                || class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
-                || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')
+            if (class_exists($class = config('revisionable.user.model'))
             ) {
                 return ($class::check()) ? $class::getUser()->id : null;
             } elseif (\Auth::check()) {

--- a/src/config/revisionable.php
+++ b/src/config/revisionable.php
@@ -1,0 +1,17 @@
+<?php
+
+return array(
+
+    // this is the default model for revisionable
+    // you can set model, connection and table name
+    'revision' => [
+        'model' => '\Venturecraft\Revisionable\Revision',
+        'connection' => env('DB_CONNECTION', 'mysql'),,
+        'table' => 'revisions',
+    ],
+
+    // this is the default model for user responsible
+    'user' => [
+        'model' => 'App\User',
+    ],
+);


### PR DESCRIPTION
This merge will add revisionable config and you can set user model and by default it will use 'App\User' model. It will no longer automatically detect what auth provider you will be using to prevent n+1 problem.
This merge will also fix migration duplicate.