### PR TITLE
Allow custom Fieldnames for TIMESTAMPs

### DIFF
--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -178,9 +178,9 @@ class Revisionable extends Eloquent
             $revisions[] = array(
                 'revisionable_type' => get_class($this),
                 'revisionable_id' => $this->getKey(),
-                'key' => 'created_at',
+                'key' => self::CREATED_AT,
                 'old_value' => null,
-                'new_value' => $this->created_at,
+                'new_value' => $this->{self::CREATED_AT},
                 'user_id' => $this->getUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
@@ -199,13 +199,13 @@ class Revisionable extends Eloquent
     {
         if ((!isset($this->revisionEnabled) || $this->revisionEnabled)
             && $this->isSoftDelete()
-            && $this->isRevisionable('deleted_at')) {
+            && $this->isRevisionable(self::DELETED_AT)) {
             $revisions[] = array(
                 'revisionable_type' => get_class($this),
                 'revisionable_id' => $this->getKey(),
-                'key' => 'deleted_at',
+                'key' => self::DELETED_AT,
                 'old_value' => null,
-                'new_value' => $this->deleted_at,
+                'new_value' => $this->{self::DELETED_AT},
                 'user_id' => $this->getUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -219,9 +219,9 @@ trait RevisionableTrait
             $revisions[] = array(
                 'revisionable_type' => get_class($this),
                 'revisionable_id' => $this->getKey(),
-                'key' => 'created_at',
+                'key' => self::CREATED_AT,
                 'old_value' => null,
-                'new_value' => $this->created_at,
+                'new_value' => $this->{self::CREATED_AT},
                 'user_id' => $this->getUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
@@ -242,14 +242,14 @@ trait RevisionableTrait
     {
         if ((!isset($this->revisionEnabled) || $this->revisionEnabled)
             && $this->isSoftDelete()
-            && $this->isRevisionable('deleted_at')
+            && $this->isRevisionable(self::DELETED_AT)
         ) {
             $revisions[] = array(
                 'revisionable_type' => get_class($this),
                 'revisionable_id' => $this->getKey(),
-                'key' => 'deleted_at',
+                'key' => self::DELETED_AT,
                 'old_value' => null,
-                'new_value' => $this->deleted_at,
+                'new_value' => $this->{self::DELETED_AT},
                 'user_id' => $this->getUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),


### PR DESCRIPTION
We should be able to use custom timestamps for created_at and deleted_at if the models have an overwritten CONST for DELETED_AT or CREATED_AT.

E.g.: http://stackoverflow.com/questions/24404474/change-name-of-laravels-created-at-and-updated-at