### PR TITLE
Added revisionable.* events

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -128,7 +128,7 @@ class Article extends Eloquent {
     protected $historyLimit = 500; //Stop tracking revisions after 500 changes have been made.
 }
 ```
-In order to maintain a limit on history, but instead of stopping tracking revisions you want to remove old revisions, you can accommodate that feature by setting `$revisionCleanup`.
+In order to maintain a limit on history, but instead of stopping tracking revisions if you want to remove old revisions, you can accommodate that feature by setting `$revisionCleanup`.
 
 ```php
 namespace MyApp\Models;
@@ -180,6 +180,25 @@ protected $dontKeepRevisionOf = array(
 ```
 
 > The `$keepRevisionOf` setting takes precendence over `$dontKeepRevisionOf`
+
+### Events
+
+Every time a model revision is created an event is fired. You can listen for `revisionable.created`,  
+`revisionable.saved` or `revisionable.deleted`.
+
+```php
+// app/Providers/EventServiceProviders.php
+public function boot(DispatcherContract $events)
+{
+    parent::boot($events);
+
+    $events->listen('revisionable.*', function($revisions) {
+        // Do something with the revisions. 
+        dd($revisions);
+    });
+}
+
+```
 
 <a name="formatoutput"></a>
 ## Format output

--- a/readme.md
+++ b/readme.md
@@ -192,9 +192,9 @@ public function boot(DispatcherContract $events)
 {
     parent::boot($events);
 
-    $events->listen('revisionable.*', function($revisions) {
-        // Do something with the revisions. 
-        dd($revisions);
+    $events->listen('revisionable.*', function($model, $revisions) {
+        // Do something with the revisions or the changed model. 
+        dd($model, $revisions);
     });
 }
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -196,6 +196,7 @@ trait RevisionableTrait
                 }
                 $revision = new Revision;
                 \DB::table($revision->getTable())->insert($revisions);
+                \Event::fire('revisionable.saved', array('revisions' => $revisions));
             }
         }
     }
@@ -229,9 +230,8 @@ trait RevisionableTrait
 
             $revision = new Revision;
             \DB::table($revision->getTable())->insert($revisions);
-
+            \Event::fire('revisionable.created', array('revisions' => $revisions));
         }
-
 
     }
 
@@ -256,6 +256,7 @@ trait RevisionableTrait
             );
             $revision = new \Venturecraft\Revisionable\Revision;
             \DB::table($revision->getTable())->insert($revisions);
+            \Event::fire('revisionable.deleted', array('revisions' => $revisions));
         }
     }
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -196,7 +196,7 @@ trait RevisionableTrait
                 }
                 $revision = new Revision;
                 \DB::table($revision->getTable())->insert($revisions);
-                \Event::fire('revisionable.saved', array('revisions' => $revisions));
+                \Event::fire('revisionable.saved', array('model' => $this, 'revisions' => $revisions));
             }
         }
     }
@@ -230,7 +230,7 @@ trait RevisionableTrait
 
             $revision = new Revision;
             \DB::table($revision->getTable())->insert($revisions);
-            \Event::fire('revisionable.created', array('revisions' => $revisions));
+            \Event::fire('revisionable.created', array('model' => $this, 'revisions' => $revisions));
         }
 
     }
@@ -256,7 +256,7 @@ trait RevisionableTrait
             );
             $revision = new \Venturecraft\Revisionable\Revision;
             \DB::table($revision->getTable())->insert($revisions);
-            \Event::fire('revisionable.deleted', array('revisions' => $revisions));
+            \Event::fire('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
         }
     }
 


### PR DESCRIPTION
Added `revisionable.created`, `revisionable.saved` and `revisionable.deleted` events to hook into.

This can be useful if you want to create notifications every time a revisionable model has been edited.

This fixes #108.