### PR TITLE
Updated migration command

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -44,7 +44,7 @@ php composer.phar update
 Finally, you'll also need to run migration on the package
 
 ```
-php artisan migrate --package=venturecraft/revisionable
+php artisan migrate --path=vendor/venturecraft/revisionable/src/migrations
 ```
 
 > If you're going to be migrating up and down completely a lot (using `migrate:refresh`), one thing you can do instead is to copy the migration file from the package to your `app/database` folder, and change the classname from `CreateRevisionsTable` to something like `CreateRevisionTable` (without the 's', otherwise you'll get an error saying there's a duplicate class)


### PR DESCRIPTION
Hi,

The actual command will give an error:

```
[Symfony\Component\Console\Exception\RuntimeException]  
The "--package" option does not exist.
```

Now this does the trick:

$ php artisan migrate --path=vendor/venturecraft/revisionable/src/migrations

 :)

Great package btw