### PR TITLE
Replace RevisionableTrait get_class() with getMorphClass()

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
             "email": "developer@roomroster.com"
         }
     ],
+    "minimum-stability": "stable",
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": ">=5.1"
@@ -18,7 +19,7 @@
         "classmap": [
             "src/migrations"
         ],
-        "psr-0": {
+        "psr-4": {
             "Venturecraft\\Revisionable": "src/"
         }
     },

--- a/composer.json
+++ b/composer.json
@@ -1,22 +1,18 @@
 {
-    "name": "venturecraft/revisionable",
+    "name": "roomroster/revisionable",
     "license": "MIT",
     "description": "Keep a revision history for your models without thinking, created as a package for use with Laravel",
     "keywords": ["model", "laravel", "ardent", "revision", "history"],
     "homepage": "http://github.com/venturecraft/revisionable",
     "authors": [
         {
-            "name": "Chris Duell",
-            "email": "me@chrisduell.com"
+            "name": "RoomRoster",
+            "email": "developer@roomroster.com"
         }
     ],
-    "support": {
-        "issues": "https://github.com/VentureCraft/revisionable/issues",
-        "source": "https://github.com/VentureCraft/revisionable"
-    },
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": "~4.0|~5.0|~5.1"
+        "illuminate/support": ">=5.1"
     },
     "autoload": {
         "classmap": [
@@ -25,5 +21,16 @@
         "psr-0": {
             "Venturecraft\\Revisionable": "src/"
         }
-    }
+    },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/RoomRoster/revisionable.git"
+        }
+    ]
 }
+
+
+
+
+

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
             "email": "developer@roomroster.com"
         }
     ],
-    "minimum-stability": "stable",
     "require": {
         "php": ">=5.3.0",
         "illuminate/support": ">=5.1"
@@ -19,8 +18,8 @@
         "classmap": [
             "src/migrations"
         ],
-        "psr-4": {
-            "Venturecraft\\Revisionable\\": "src/"
+        "psr-0": {
+            "Venturecraft\\Revisionable": "src/"
         }
     },
     "repositories": [
@@ -30,8 +29,3 @@
         }
     ]
 }
-
-
-
-
-

--- a/composer.json
+++ b/composer.json
@@ -20,7 +20,7 @@
             "src/migrations"
         ],
         "psr-4": {
-            "Venturecraft\\Revisionable": "src/"
+            "Venturecraft\\Revisionable\\": "src/"
         }
     },
     "repositories": [

--- a/composer.json
+++ b/composer.json
@@ -1,18 +1,22 @@
 {
-    "name": "roomroster/revisionable",
+    "name": "venturecraft/revisionable",
     "license": "MIT",
     "description": "Keep a revision history for your models without thinking, created as a package for use with Laravel",
     "keywords": ["model", "laravel", "ardent", "revision", "history"],
     "homepage": "http://github.com/venturecraft/revisionable",
     "authors": [
         {
-            "name": "RoomRoster",
-            "email": "developer@roomroster.com"
+            "name": "Chris Duell",
+            "email": "me@chrisduell.com"
         }
     ],
+    "support": {
+        "issues": "https://github.com/VentureCraft/revisionable/issues",
+        "source": "https://github.com/VentureCraft/revisionable"
+    },
     "require": {
         "php": ">=5.3.0",
-        "illuminate/support": ">=5.1"
+        "illuminate/support": "~4.0|~5.0|~5.1"
     },
     "autoload": {
         "classmap": [
@@ -21,11 +25,5 @@
         "psr-0": {
             "Venturecraft\\Revisionable": "src/"
         }
-    },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/RoomRoster/revisionable.git"
-        }
-    ]
+    }
 }

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -176,7 +176,7 @@ trait RevisionableTrait
 
             foreach ($changes_to_record as $key => $change) {
                 $revisions[] = array(
-                    'revisionable_type' => get_class($this),
+                    'revisionable_type' => $this->getMorphClass(),
                     'revisionable_id' => $this->getKey(),
                     'key' => $key,
                     'old_value' => array_get($this->originalData, $key),
@@ -217,7 +217,7 @@ trait RevisionableTrait
         if ((!isset($this->revisionEnabled) || $this->revisionEnabled))
         {
             $revisions[] = array(
-                'revisionable_type' => get_class($this),
+                'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
                 'key' => 'created_at',
                 'old_value' => null,

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -245,7 +245,7 @@ trait RevisionableTrait
             && $this->isRevisionable('deleted_at')
         ) {
             $revisions[] = array(
-                'revisionable_type' => get_class($this),
+                'revisionable_type' => $this->getMorphClass(),
                 'revisionable_id' => $this->getKey(),
                 'key' => 'deleted_at',
                 'old_value' => null,


### PR DESCRIPTION
The `RevisionableTrait` does not consider the morph map when inserting the `revisionable_type` into the database. Morph map can be used so that the type is stored as something different than the class name. In our case we are using the morph map to store the table name instead.

This is supported in laravel 4.1 and greater.