### PR TITLE
Enable to choose db connection

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -33,7 +33,7 @@ class Revision extends Eloquent
         parent::__construct($attributes);
 
         if (\Config::has('revisionable.db_connection')) {
-            $this->connection = Config::get('revisionable.db_connection');
+            $this->connection = \Config::get('revisionable.db_connection');
         }
     }
 

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -31,6 +31,10 @@ class Revision extends Eloquent
     public function __construct(array $attributes = array())
     {
         parent::__construct($attributes);
+
+        if (\Config::has('revisionable.db_connection')) {
+            $this->connection = Config::get('revisionable.db_connection');
+        }
     }
 
     /**

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -154,7 +154,7 @@ class Revisionable extends Eloquent
 
             if (count($revisions) > 0) {
                 $revision = new Revision;
-                \DB::table($revision->getTable())->insert($revisions);
+                \DB::connection(\Config::get('revisionable.db_connection') ?? null)->table($revision->getTable())->insert($revisions);
             }
         }
     }
@@ -187,7 +187,7 @@ class Revisionable extends Eloquent
             );
 
             $revision = new Revision;
-            \DB::table($revision->getTable())->insert($revisions);
+            \DB::connection(\Config::get('revisionable.db_connection') ?? null)->table($revision->getTable())->insert($revisions);
 
         }
     }
@@ -211,7 +211,7 @@ class Revisionable extends Eloquent
                 'updated_at' => new \DateTime(),
             );
             $revision = new \Venturecraft\Revisionable\Revision;
-            \DB::table($revision->getTable())->insert($revisions);
+            \DB::connection(\Config::get('revisionable.db_connection') ?? null)->table($revision->getTable())->insert($revisions);
         }
     }
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -195,7 +195,7 @@ trait RevisionableTrait
                     }
                 }
                 $revision = new Revision;
-                \DB::table($revision->getTable())->insert($revisions);
+                \DB::connection(\Config::get('revisionable.db_connection') ?? null)->table($revision->getTable())->insert($revisions);
                 \Event::fire('revisionable.saved', array('model' => $this, 'revisions' => $revisions));
             }
         }
@@ -229,7 +229,7 @@ trait RevisionableTrait
             );
 
             $revision = new Revision;
-            \DB::table($revision->getTable())->insert($revisions);
+            \DB::connection(\Config::get('revisionable.db_connection') ?? null)->table($revision->getTable())->insert($revisions);
             \Event::fire('revisionable.created', array('model' => $this, 'revisions' => $revisions));
         }
 
@@ -255,7 +255,7 @@ trait RevisionableTrait
                 'updated_at' => new \DateTime(),
             );
             $revision = new \Venturecraft\Revisionable\Revision;
-            \DB::table($revision->getTable())->insert($revisions);
+            \DB::connection(\Config::get('revisionable.db_connection') ?? null)->table($revision->getTable())->insert($revisions);
             \Event::fire('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
         }
     }


### PR DESCRIPTION
Enable to choose db connection by creating simple config file:
`config/revisionable.php`

For example:

`
return [
    'db_connection' => 'mysql-revision'
];`
