### PR TITLE
Fix when using morphMap in Laravel >= 5.2

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -75,7 +75,7 @@ class Revision extends Eloquent
      */
     private function formatFieldName($key)
     {
-        $related_model = $this->revisionable_type;
+        $related_model = $this->getActualClassNameForMorph($this->revisionable_type);
         $related_model = new $related_model;
         $revisionFormattedFieldNames = $related_model->getRevisionFormattedFieldNames();
 
@@ -278,7 +278,7 @@ class Revision extends Eloquent
      */
     public function format($key, $value)
     {
-        $related_model = $this->revisionable_type;
+        $related_model = $this->getActualClassNameForMorph($this->revisionable_type);
         $related_model = new $related_model;
         $revisionFormattedFields = $related_model->getRevisionFormattedFields();
 


### PR DESCRIPTION
In the App Service Provider I am using
```
		Relation::morphMap( [
			'posts'         => Post::class,
			'prescriptions' => Prescription::class,
			'events'        => Event::class,
			'feelings'      => Feeling::class,
			'troubles'      => Trouble::class,
			'stories'       => Story::class
		] );
```
Revisionable correctly stores the `reviosionable_type` as `posts` in the DB but when you use the Revionable methods `formatFieldName` and `format` it trys to new up a class called `posts` which doesn't exist. They need to be run through the method `getActualClassNameForMorph` first to see if the class name needs morphing to the full class name.

This fix will only work for Laravel >= 5.2 and welcome to suggestions on how to keep backwards compatibility.

For the meantime if anyone wants to run this they can make the following changes:

Add my repo to composer repositories:

```
        {
            "type": "vcs",
            "url": "https://github.com/brightrobots/revisionable"
        }
```

Then require reviosionable in composer:

```
"venturecraft/revisionable": "dev-fix-map-morph as 1.28.0",
```

This even works if reviosionable is pulled in as a dependency by another package