### PR TITLE
Don't log if nothing is wrong (again)

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -172,7 +172,6 @@ class Revision extends Eloquent
             } catch (\Exception $e) {
                 // Just a fail-safe, in the case the data setup isn't as expected
                 // Nothing to do here.
-                Log::info('Revisionable: ' . $e);
             }
 
             // if there was an issue


### PR DESCRIPTION
Hi!

The issue linked with this pull request probably has a long history; see, for example, https://github.com/VentureCraft/revisionable/issues/186, https://github.com/VentureCraft/revisionable/pull/279 and https://github.com/sebastienheyd/revisionable/commit/05aedc612d26162ec3882a26c3b5de29145b94f7. It's been almost 1.5 years already. While this pull requests only concerns with removing a single line of code, given the time it took to resolve the issue, I'd like to explain the rationale in detail.

The basic, fundamental issue is:
**When using `Revisionable`, Laravel logs are randomly flooded with `INFO` level messages.**

The messages are neither informative for end users, nor indicative of a failure or wrong usage of the library; however, due to their sheer number, they look frightening and hinder the discovery of real problems in a live environment, rendering Laravel logging useless unless using a log analyser.

Log entries in question look like:
```
[2017-01-12 19:24:21] production.INFO: Revisionable: Exception: Relation yandexTransaction does not exist for [] in <erased>/vendor/venturecraft/revisionable/src/Venturecraft/Revision
Stack trace:
#0 <erased>/vendor/venturecraft/revisionable/src/Venturecraft/Revisionable/Revision.php(99): Venturecraft\Revisionable\Revision->getValue('old')
#1 <erased>/storage/framework/views/8d043b63345601d2630e9b1758f95c5eac216ba8.php(64): Venturecraft\Revisionable\Revision->oldValue()
#2 <erased>/bootstrap/cache/compiled.php(15452): include('<erased>...')
...
#53 <erased>/bootstrap/cache/compiled.php(2399): Illuminate\Foundation\Http\Kernel->sendRequestThroughRouter(Object(Illuminate\Http\Request))
#54 <erased>/public/index.php(55): Illuminate\Foundation\Http\Kernel->handle(Object(Illuminate\Http\Request))
#55 {main}
```

This becomes a real problem when one's production log reach a few GB in size, most of them being false positives. Given that each log entry takes about 50 kB, it's not unreasonable.

The statement responsible for this is:
https://github.com/VentureCraft/revisionable/blob/master/src/Venturecraft/Revisionable/Revision.php#L175

The statement is obviously a part of heuristic logic which attempts to tell apart regular model attributes from relations. In short, whenever `Revision` encounters a field name ending in `_id`, it tries to use relation of corresponding name instead; when failed, it falls back to treating the field as regular attribute.

There are a few use cases where the above logic fails, all of them are fairly likely to occur in a live real-world project:

- The model might have an attribute ending in `_id` despite not being a relation.

  In my recent project, we had an `Order` model which, in turn, had `crm_id` and `transaction_id` attributes. These were not relations, but rather identifiers we receive from external systems, which had to store for future interactions. They did, however, hold the values you'd think they hold, so their names were not unreasonable (i.e. "CRM ID" and "transaction ID" were fairly descriptive names) and there were no reasons to think the names might be wrong.

- The attribute is, in fact, a relation, but the relation was never explicitly defined as such.

  I.e. one might have `category_id` attribute defined, but not its corresponding `category()` method just because it wasn't yet necessary. The `$main_model->$related_model()` call will obviously fail in this case.

- There is an attribute and the corresponding relation definition, but the related model neither use `RevisionableTrait` nor inherit from `Revisionable` (in other words, does not have its revisions tracked).

  This is the use case presumably handled by the https://github.com/sebastienheyd/revisionable/commit/05aedc612d26162ec3882a26c3b5de29145b94f7 commit.

That said, there's nothing inherently wrong with the heuristic logic itself<sup>[1](#footnote)</sup>.

I've looked into adjusting the logic in attempt to get rid of using exceptions altogether. However, it does not seem to be possible with Laravel, right now, since one currently cannot reliably enumerate `Eloquent`-derived model relations (see e.g. http://stackoverflow.com/questions/21615656/get-array-of-eloquent-models-relations).

In other words, there's no way you could do the same without using exception handling.

While one could argue about having more elegant solutions, the current one does everything it needs in a straightforward and sufficiently clear way; it does use exceptions to indicate failure, but there's probably no way around that. The important part is that exceptions are only used internally.

The only problem is that the code does log its internal exceptions, which are, in fact, part of its normal operation.

Looking into `git blame` in detail, I can see that the logging statement does not have any special purpose.
Considering the above, I strongly suggest simply removing the offending statement - which this pull request does.

Thank you for taking your time to read this!

---

<a id="footnote"><sup>1</sup></a> Actually, calling a heuristically derived method is not at all safe.

Consider, for example, a model representing an e-commerce order that is delivered by mail. It might have a `post_id` attribute, which is supposed to keep either tracking number or post office ID which is responsible for delivery; at the same time, it might have a completely independent method `post()` which, in fact, does "post" the package by sending a message into delivery company API.

Should `Revisionable` call this method, the order might be delivered prematurely; for example, before the payment has been settled. Given that `revisionHistory` relation is probably only accessed in administrative area (i.e. CMS), it might as well not be covered by unit tests, even though critical parts of the system are. (Hopefully the method would be `protected`, but things happen.)

This use case is, however, outside the scope of this pull request.