### PR TITLE
Don't serialize empty models

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -140,7 +140,7 @@ class Revision extends Eloquent
                     if (!method_exists($main_model, $related_model)) {
                         $related_model = camel_case($related_model); // for cases like published_status_id
                         if (!method_exists($main_model, $related_model)) {
-                            throw new \Exception('Relation ' . $related_model . ' does not exist for ' . $main_model);
+                            throw new \Exception('Relation ' . $related_model . ' does not exist for ' . get_class($main_model));
                         }
                     }
                     $related_class = $main_model->$related_model()->getRelated();


### PR DESCRIPTION
Hey, me again.

This one is probably a typo.

There's an internal exception which uses `$main_model` as part of its message. The `$main_model` variable initially holds class name of the revisioned model, but is later reassigned to hold an empty instance of the class, causing PHP to serialize the instance. (`__toString()` method calls `toJson()`, which eventually calls `toArray()`).

The problem is, the model might not expect to be serialized when empty, or when not saved (e.g. it may expect a relation to be present). Any exception thrown within `__toString()` method generates an `E_ERROR` ― which is obviously not an exception, but a PHP error, and thus leaks into main application with a rather uninformative error message; like `Method App\Car::__toString() must not throw an exception, caught Error: Call to a member function map() on null` with no stack trace.

I've replaced it with original class name, which is logical in this place.