### PR TITLE
Check if attribute is cast to json or array

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,26 +1,32 @@
 {
-    "name": "venturecraft/revisionable",
-    "license": "MIT",
-    "description": "Keep a revision history for your models without thinking, created as a package for use with Laravel",
-    "keywords": ["model", "laravel", "ardent", "revision", "history"],
-    "homepage": "http://github.com/venturecraft/revisionable",
-    "authors": [
-        {
-            "name": "Chris Duell",
-            "email": "me@chrisduell.com"
-        }
-    ],
-    "support": {
-        "issues": "https://github.com/VentureCraft/revisionable/issues",
-        "source": "https://github.com/VentureCraft/revisionable"
-    },
-    "require": {
-        "php": ">=5.3.0",
-        "illuminate/support": "~4.0|~5.0|~5.1"
-    },
-    "autoload": {
-        "psr-0": {
-            "Venturecraft\\Revisionable": "src/"
-        }
+  "name": "venturecraft/revisionable",
+  "license": "MIT",
+  "description": "Keep a revision history for your models without thinking, created as a package for use with Laravel",
+  "keywords": [
+    "model",
+    "laravel",
+    "ardent",
+    "revision",
+    "history"
+  ],
+  "homepage": "http://github.com/venturecraft/revisionable",
+  "authors": [
+    {
+      "name": "Chris Duell",
+      "email": "me@chrisduell.com"
     }
+  ],
+  "support": {
+    "issues": "https://github.com/VentureCraft/revisionable/issues",
+    "source": "https://github.com/VentureCraft/revisionable"
+  },
+  "require": {
+    "php": ">=7.0.0",
+    "illuminate/support": "~4.0|~5.0|~5.1"
+  },
+  "autoload": {
+    "psr-0": {
+      "Venturecraft\\Revisionable": "src/"
+    }
+  }
 }

--- a/composer.json
+++ b/composer.json
@@ -19,9 +19,6 @@
         "illuminate/support": "~4.0|~5.0|~5.1"
     },
     "autoload": {
-        "classmap": [
-            "src/migrations"
-        ],
         "psr-0": {
             "Venturecraft\\Revisionable": "src/"
         }

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -122,7 +122,10 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-                if (gettype($val) == 'object' && !method_exists($val, '__toString')) {
+                if (isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array'])) {
+                    // Reformat JSON to remove whitespaces so it doesn't false flag it as changed
+                    $this->originalData[$key] = json_encode(json_decode($val));
+                } else if (gettype($val) == 'object' && !method_exists($val, '__toString')) {
                     unset($this->originalData[$key]);
                     unset($this->updatedData[$key]);
                     array_push($this->dontKeep, $key);

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -124,7 +124,7 @@ trait RevisionableTrait
             foreach ($this->updatedData as $key => $val) {
                 if (isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array'])) {
                     // Reformat JSON to remove whitespaces so it doesn't false flag it as changed
-                    $this->originalData[$key] = json_encode(json_decode($val));
+                    $this->originalData[$key] = json_encode(json_decode($this->originalData[$key]));
                 } else if (gettype($val) == 'object' && !method_exists($val, '__toString')) {
                     unset($this->originalData[$key]);
                     unset($this->updatedData[$key]);

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -270,16 +270,9 @@ trait RevisionableTrait
     public function getSystemUserId()
     {
         try {
-            if (class_exists($class = '\SleepingOwl\AdminAuth\Facades\AdminAuth')
-                || class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
-                || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')
-            ) {
-                return ($class::check()) ? $class::getUser()->id : null;
-            } elseif (\Auth::check()) {
-                return \Auth::user()->getAuthIdentifier();
-            }
+            return \Auth::id();
         } catch (\Exception $e) {
-            return null;
+
         }
 
         return null;

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -122,7 +122,7 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-                if (isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array'])) {
+                if (isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
                     // Reformat JSON to remove whitespaces so it doesn't false flag it as changed
                     $this->originalData[$key] = json_encode(json_decode($this->originalData[$key]));
                 } else if (gettype($val) == 'object' && !method_exists($val, '__toString')) {


### PR DESCRIPTION
Hopefully self explanatory. We leverage a lot of JSON fields on our tables so just saving the cast objects would result in a revision hit. This basically just removes the extra whitespace by encoding and decoding it. 