### PR TITLE
Mark package as abandoned

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,7 @@
             "email": "me@chrisduell.com"
         }
     ],
+    "abandoned": true,
     "support": {
         "issues": "https://github.com/VentureCraft/revisionable/issues",
         "source": "https://github.com/VentureCraft/revisionable"


### PR DESCRIPTION
As the number of MR's and Issues has stacked up and the original author appears to no longer wish to do anything to this (including answering people) this should really be marked as abandoned to save people wasting their time. This will flag it on packagist as abandoned, which will allow people to use alternatives.