### PR TITLE
Possibility to specify custom table name and database connection

### DIFF
--- a/config/revisionable.php
+++ b/config/revisionable.php
@@ -1,0 +1,6 @@
+<?php
+
+return array(
+  'revisions_table_name' => 'revisions',
+  'revisions_db_connection' => config('database.default')
+);

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,12 @@ Finally, you'll also need to run migration on the package (Laravel 5.x)
 php artisan migrate --path=vendor/venturecraft/revisionable/src/migrations
 ```
 
+If you want to change the default table name and/or database connection you can publish package config file (Laravel 5.x)
+
+```
+php artisan vendor:publish --provider="Venturecraft\Revisionable\RevisionableServiceProvider" --tag="config"
+```
+
 For Laravel 4.x users:
 ```
 php artisan migrate --package=venturecraft/revisionable

--- a/readme.md
+++ b/readme.md
@@ -46,6 +46,12 @@ Finally, you'll also need to run migration on the package (Laravel 5.x)
 php artisan migrate --path=vendor/venturecraft/revisionable/src/migrations
 ```
 
+Register service provider in your app.php:
+
+```
+Venturecraft\Revisionable\RevisionableServiceProvider::class
+```
+
 If you want to change the default table name and/or database connection you can publish package config file (Laravel 5.x)
 
 ```

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -18,7 +18,8 @@ class Revision extends Eloquent
     /**
      * @var string
      */
-    public $table = 'revisions';
+    public $table;
+    protected $connection;
 
     /**
      * @var array
@@ -30,6 +31,9 @@ class Revision extends Eloquent
      */
     public function __construct(array $attributes = array())
     {
+        $this->table = config('revisionable.revisions_table_name');
+        $this->connection = config('revisionable.revisions_db_connection');
+
         parent::__construct($attributes);
     }
 

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -154,7 +154,7 @@ class Revisionable extends Eloquent
 
             if (count($revisions) > 0) {
                 $revision = new Revision;
-                \DB::table($revision->getTable())->insert($revisions);
+                \DB::connection(config('revisionable.revisions_db_connection'))->table($revision->getTable())->insert($revisions);
             }
         }
     }
@@ -187,7 +187,7 @@ class Revisionable extends Eloquent
             );
 
             $revision = new Revision;
-            \DB::table($revision->getTable())->insert($revisions);
+            \DB::connection(config('revisionable.revisions_db_connection'))->table($revision->getTable())->insert($revisions);
 
         }
     }
@@ -211,7 +211,7 @@ class Revisionable extends Eloquent
                 'updated_at' => new \DateTime(),
             );
             $revision = new \Venturecraft\Revisionable\Revision;
-            \DB::table($revision->getTable())->insert($revisions);
+            \DB::connection(config('revisionable.revisions_db_connection'))->table($revision->getTable())->insert($revisions);
         }
     }
 

--- a/src/Venturecraft/Revisionable/RevisionableServiceProvider.php
+++ b/src/Venturecraft/Revisionable/RevisionableServiceProvider.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace Venturecraft\Revisionable;
+use Illuminate\Support\ServiceProvider;
+
+class RevisionableServiceProvider extends ServiceProvider
+{
+
+    /**
+     * Bootstrap the application events.
+     */
+    public function boot()
+    {
+        $this->publishes([
+            __DIR__.'/../../../config/revisionable.php' => config_path('revisionable.php'),
+        ], 'config');
+    }
+
+    /**
+     * Register the service provider.
+     */
+    public function register()
+    {
+        $this->mergeConfigFrom(__DIR__.'/../../../config/revisionable.php', 'revisionable');
+    }
+}


### PR DESCRIPTION
I think it'll be useful to be able to set custom table name for revisions. Also it would be good to be able to set custom connection, in my use case I want to split revisions in a separate database in order to speed up the backup/restore of the main database who in total is smaller than the revisions table alone :)