### PR TITLE
using Event::dispatch instead of deprecated Event::fire method

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -196,7 +196,7 @@ trait RevisionableTrait
                 }
                 $revision = new Revision;
                 \DB::table($revision->getTable())->insert($revisions);
-                \Event::fire('revisionable.saved', array('model' => $this, 'revisions' => $revisions));
+                \Event::dispatch('revisionable.saved', array('model' => $this, 'revisions' => $revisions));
             }
         }
     }
@@ -230,7 +230,7 @@ trait RevisionableTrait
 
             $revision = new Revision;
             \DB::table($revision->getTable())->insert($revisions);
-            \Event::fire('revisionable.created', array('model' => $this, 'revisions' => $revisions));
+            \Event::dispatch('revisionable.created', array('model' => $this, 'revisions' => $revisions));
         }
 
     }
@@ -256,7 +256,7 @@ trait RevisionableTrait
             );
             $revision = new \Venturecraft\Revisionable\Revision;
             \DB::table($revision->getTable())->insert($revisions);
-            \Event::fire('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
+            \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
         }
     }
 


### PR DESCRIPTION
fixes issue #341 

In the Laravel [5.8 docs](https://laravel.com/docs/5.8/upgrade#upgrade-5.8.0):

> The fire method (which was deprecated in Laravel 5.4) of the  Illuminate/Events/Dispatcher class has been removed. You should use the dispatch method instead.