### PR TITLE
Add support to JSON fields

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -190,6 +190,7 @@ trait RevisionableTrait
                 if (is_array($originalData) && is_array($updatedData)) {
                     // remove nulls and duplicates
                     $updatedData = array_filter(array_diff_assoc($updatedData, $originalData));
+                    $originalData = array_filter(array_diff_assoc($originalData, $updatedData));
                 }
 
                 $revisions[] = array(


### PR DESCRIPTION
I ended up with this solution in a fork of this project that I've worked on.

If a json `{ "title": "foo", "description": "bar" }` is updated to `{ "title": "foo", "description": "baz" }` it will keep only the updated field on _revisions_:

old_value: `{ "description": "bar" }`
new_value: `{ "description": "baz" }`

#337 #210