### PR TITLE
Allow Laravel 6.0 composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php": ">=5.4.0",
         "illuminate/support": "~4.0|~5.0|~5.1|^6.0",
-        "laravel/framework": "~5.4"
+        "laravel/framework": "~5.4|^6.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
@duellsy I see that you've already updated the ```illuminate/support``` dependecy to support Laravel 6. But another dependency is ```laravel/framework``` - so we need to update that one too.

That's the only thing this PR does.

Could you please merge&tag this so we can install on Laravel 6 too?

Thanks!