### PR TITLE
Added the output format for values - "options".

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -253,6 +253,14 @@ Booleans by default will display as a 0 or a 1, which is pretty bland and won't 
 boolean:No|Yes
 ```
 
+### Options
+Analogous to "boolean", only any text or numeric values can act as a source value (often flags are stored in the database). The format allows you to specify different outputs depending on the value.
+Look at this as an associative array in which the key is separated from the value by a dot. Array elements are separated by a vertical line.
+
+```
+options: search.On the search|network.In networks
+```
+
 ### DateTime
 DateTime by default will display as Y-m-d H:i:s. Prefix the value with `datetime:` and then add your datetime format, e.g.,
 

--- a/src/Venturecraft/Revisionable/FieldFormatter.php
+++ b/src/Venturecraft/Revisionable/FieldFormatter.php
@@ -117,4 +117,29 @@ class FieldFormatter
 
         return $datetime->format($format);
     }
+
+    /**
+     * Format options
+     *
+     * @param string $value
+     * @param string $format
+     * @return string
+     */
+    public static function options($value, $format)
+    {
+        $options = explode('|', $format);
+
+        $result = [];
+
+        foreach ($options as $option) {
+            $transform = explode('.', $option);
+            $result[$transform[0]] = $transform[1];
+        }
+
+        if (isset($result[$value])) {
+            return $result[$value];
+        }
+
+        return 'undefined';
+    }
 }


### PR DESCRIPTION
Analogous to "boolean", only any text or numeric values can act as a source value (often flags are stored in the database). The format allows you to specify different outputs depending on the value.

options: search.On the search|network.In networks

Look at this as an associative array in which the key is separated from the value by a dot. Array elements are separated by a vertical line.