### PR TITLE
Added storing Force Delete

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -253,6 +253,14 @@ Booleans by default will display as a 0 or a 1, which is pretty bland and won't 
 boolean:No|Yes
 ```
 
+### Options
+Analogous to "boolean", only any text or numeric values can act as a source value (often flags are stored in the database). The format allows you to specify different outputs depending on the value.
+Look at this as an associative array in which the key is separated from the value by a dot. Array elements are separated by a vertical line.
+
+```
+options: search.On the search|network.In networks
+```
+
 ### DateTime
 DateTime by default will display as Y-m-d H:i:s. Prefix the value with `datetime:` and then add your datetime format, e.g.,
 

--- a/readme.md
+++ b/readme.md
@@ -172,7 +172,7 @@ If you want to store the Force Delete as a revision you can override this behavi
 protected $revisionForceDeleteEnabled = true;
 ```
 
-In which case, the `created_at` field will be stored as a key with the `oldValue()` value equal to the model creation date and the `newValue()` value equal to null.
+In which case, the `created_at` field will be stored as a key with the `oldValue()` value equal to the model creation date and the `newValue()` value equal to `null`.
 
 **Attention!** Turn on this setting carefully! Since the model saved in the revision, now does not exist, so you will not be able to get its object or its relations. 
 

--- a/readme.md
+++ b/readme.md
@@ -164,6 +164,14 @@ To better format the output for `deleted_at` entries, you can use the `isEmpty` 
 
 <a name="control"></a>
 
+### Storing Force Delete
+By default the Force Delete of a model is not stored as a revision.
+
+If you want to store the Force Delete as a revision you can override this behavior by setting `revisionForceDeleteEnabled ` to `true` by adding the following to your model:
+```php
+protected $revisionForceDeleteEnabled = true;
+```
+
 ### Storing Creations
 By default the creation of a new model is not stored as a revision.
 Only subsequent changes to a model is stored.

--- a/readme.md
+++ b/readme.md
@@ -172,6 +172,10 @@ If you want to store the Force Delete as a revision you can override this behavi
 protected $revisionForceDeleteEnabled = true;
 ```
 
+In which case, the `created_at` field will be stored as a key with the `oldValue()` value equal to the model creation date and the `newValue()` value equal to null.
+
+**Attention!** Turn on this setting carefully! Since the model saved in the revision, now does not exist, so you will not be able to get its object or its relations. 
+
 ### Storing Creations
 By default the creation of a new model is not stored as a revision.
 Only subsequent changes to a model is stored.

--- a/src/Venturecraft/Revisionable/FieldFormatter.php
+++ b/src/Venturecraft/Revisionable/FieldFormatter.php
@@ -117,4 +117,29 @@ class FieldFormatter
 
         return $datetime->format($format);
     }
+
+    /**
+     * Format options
+     *
+     * @param string $value
+     * @param string $format
+     * @return string
+     */
+    public static function options($value, $format)
+    {
+        $options = explode('|', $format);
+
+        $result = [];
+
+        foreach ($options as $option) {
+            $transform = explode('.', $option);
+            $result[$transform[0]] = $transform[1];
+        }
+
+        if (isset($result[$value])) {
+            return $result[$value];
+        }
+
+        return 'undefined';
+    }
 }

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -72,6 +72,7 @@ class Revisionable extends Eloquent
         static::deleted(function ($model) {
             $model->preSave();
             $model->postDelete();
+            $model->postForceDelete();
         });
     }
     /**
@@ -221,6 +222,37 @@ class Revisionable extends Eloquent
             );
             $revision = static::newModel();
             \DB::table($revision->getTable())->insert($revisions);
+        }
+    }
+
+    /**
+     * If forcedeletes are enabled, set the value created_at of model to null
+     *
+     * @return void|bool
+     */
+    public function postForceDelete()
+    {
+        if (empty($this->revisionForceDeleteEnabled)) {
+            return false;
+        }
+
+        if ((!isset($this->revisionEnabled) || $this->revisionEnabled)
+            && (($this->isSoftDelete() && $this->isForceDeleting()) || !$this->isSoftDelete())) {
+
+            $revisions[] = array(
+                'revisionable_type' => $this->getMorphClass(),
+                'revisionable_id' => $this->getKey(),
+                'key' => self::CREATED_AT,
+                'old_value' => $this->{self::CREATED_AT},
+                'new_value' => null,
+                'user_id' => $this->getSystemUserId(),
+                'created_at' => new \DateTime(),
+                'updated_at' => new \DateTime(),
+            );
+
+            $revision = Revisionable::newModel();
+            \DB::table($revision->getTable())->insert($revisions);
+            \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
         }
     }
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -84,6 +84,7 @@ trait RevisionableTrait
         static::deleted(function ($model) {
             $model->preSave();
             $model->postDelete();
+            $model->postForceDelete();
         });
     }
 
@@ -265,6 +266,37 @@ trait RevisionableTrait
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
             );
+            $revision = Revisionable::newModel();
+            \DB::table($revision->getTable())->insert($revisions);
+            \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
+        }
+    }
+
+    /**
+     * If forcedeletes are enabled, set the value created_at of model to null
+     *
+     * @return void|bool
+     */
+    public function postForceDelete()
+    {
+        if (empty($this->revisionForceDeleteEnabled)) {
+            return false;
+        }
+
+        if ((!isset($this->revisionEnabled) || $this->revisionEnabled)
+            && (($this->isSoftDelete() && $this->isForceDeleting()) || !$this->isSoftDelete())) {
+
+            $revisions[] = array(
+                'revisionable_type' => $this->getMorphClass(),
+                'revisionable_id' => $this->getKey(),
+                'key' => self::CREATED_AT,
+                'old_value' => $this->{self::CREATED_AT},
+                'new_value' => null,
+                'user_id' => $this->getSystemUserId(),
+                'created_at' => new \DateTime(),
+                'updated_at' => new \DateTime(),
+            );
+
             $revision = Revisionable::newModel();
             \DB::table($revision->getTable())->insert($revisions);
             \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));


### PR DESCRIPTION
Hello! 

Many users have asked to add a force delete model save. I also use this in my projects. 

I think I have found a solution and I offer it to you. It is very simple. We will save `created_at` field as the key, and the values: `oldValue` it is the `created_at` field, newValue it is `null`. That is, this behavior is completely opposite to preserving the creation of the model. 

I described everything in the README. Please take a look.
