### PR TITLE
use newer conventions

### DIFF
--- a/src/migrations/2013_04_09_062329_create_revisions_table.php
+++ b/src/migrations/2013_04_09_062329_create_revisions_table.php
@@ -12,10 +12,10 @@ class CreateRevisionsTable extends Migration
     public function up()
     {
         Schema::create('revisions', function ($table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('revisionable_type');
-            $table->integer('revisionable_id');
-            $table->integer('user_id')->nullable();
+            $table->unsignedBigInteger('revisionable_id');
+            $table->unsignedBigInteger('user_id')->nullable();
             $table->string('key');
             $table->text('old_value')->nullable();
             $table->text('new_value')->nullable();
@@ -32,6 +32,6 @@ class CreateRevisionsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('revisions');
+        Schema::dropIfExists('revisions');
     }
 }


### PR DESCRIPTION
use larger integers for ID's and in down function change to dropIfExists, to prevent a potential failure