### PR TITLE
Ability to add aditional fields

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /vendor
 composer.lock
+/.idea
+.phpunit.result.cache

--- a/readme.md
+++ b/readme.md
@@ -192,11 +192,11 @@ protected $dontKeepRevisionOf = ['category_id'];
 ### Storing additional fields in revisions
 
 In some cases, you'll want additional metadata from the models in each revision. An example of this might be if you 
-have to keep track of accounts as well as users. Simply create a migration to add the fields you'd like to your revision model,
-add them to your config/revisionable.php separated by pipes like so:
+have to keep track of accounts as well as users. Simply create your own new migration to add the fields you'd like to your revision model,
+add them to your config/revisionable.php in an array like so:
 
 ```php 
-'additional_fields_in_model' => "account_id|permissions_id|other_id", 
+'additional_fields' => ['account_id', 'permissions_id', 'other_id'], 
 ```
 
 If the column exists in the model, it will be included in the revision. 

--- a/readme.md
+++ b/readme.md
@@ -189,6 +189,21 @@ protected $dontKeepRevisionOf = ['category_id'];
 
 > The `$keepRevisionOf` setting takes precedence over `$dontKeepRevisionOf`
 
+### Storing additional fields in revisions
+
+In some cases, you'll want additional metadata from the models in each revision. An example of this might be if you 
+have to keep track of accounts as well as users. Simply create a migration to add the fields you'd like to your revision model,
+add them to your config/revisionable.php separated by pipes like so:
+
+```php 
+'additional_fields_in_model' => "account_id|permissions_id|other_id", 
+```
+
+If the column exists in the model, it will be included in the revision. 
+
+Make sure that if you can't guarantee the column in every model, you make that column ```nullable()``` in your migrations.  
+
+
 ### Events
 
 Every time a model revision is created an event is fired. You can listen for `revisionable.created`,  

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -309,35 +309,14 @@ trait RevisionableTrait
         $additional = [];
         //Determine if there are any additional fields we'd like to add to our model contained in the config file, and
         //get them into an array.
-        $fields = $this->getAdditionalFieldNames();
-        foreach($fields as $field)
-        {
-            if(Arr::has($this->originalData, $field))
-            {
+        $fields = config('revisionable.additional_fields', []);
+        foreach($fields as $field) {
+            if(Arr::has($this->originalData, $field)) {
                 $additional[$field]  =  Arr::get($this->originalData, $field);
             }
         }
 
         return $additional;
-    }
-
-
-    /**
-     * Get any fields that should be included in the revision model that have been selected in
-     * config/revisionable.php
-     *
-     * @return array fields
-     */
-    public function getAdditionalFieldNames()
-    {
-        if(config('revisionable.additional_fields_in_model', null) != null) {
-
-            $fields = config('revisionable.additional_fields_in_model', null);
-            $fields = explode('|', $fields);
-            return $fields;
-        }
-
-        return [];
     }
 
     /**

--- a/src/config/revisionable.php
+++ b/src/config/revisionable.php
@@ -7,4 +7,7 @@ return [
     |--------------------------------------------------------------------------
     */
     'model' => Venturecraft\Revisionable\Revision::class,
+
+    'additional_fields' => [],
+
 ];

--- a/tests/migrations/2020_01_02_062329_add_additional_field_to_revisions.php
+++ b/tests/migrations/2020_01_02_062329_add_additional_field_to_revisions.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddAdditionalFieldToRevisions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('revisions', function (Blueprint $table) {
+            $table->string('additional_field')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}

--- a/tests/migrations/2020_01_02_062330_add_additional_field_to_users.php
+++ b/tests/migrations/2020_01_02_062330_add_additional_field_to_users.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+
+class AddAdditionalFieldToUsers extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->string('additional_field')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        //
+    }
+}


### PR DESCRIPTION
Howdy!

Our platform tracks more than just user changes since a user can be apart of many accounts. We thought it would be useful to be able to add additional fields to the revision model such that you could be able to see what a user did in any given account. 

- We added a test to make sure none of this breaks the original awesome functionality.

- We used the config file and native PHP data types to make it easy to specify which additional columns should be included in the model.

- We added some documentation to the readme to make sure people utilizing this additional functionality know how to do it,.

- We added a test, `testRevisionSkipsAdditionalFieldsWhenMisconfigured()` to make sure that if  someone makes a mistake, we don't break their functionality.

We really appreciate all the hard work you've put into this package and would like to keep using the base branch. 

We humbly submit this pull request so everyone can benefit from our use case! 

Thanks,

Josh Ziering

