### PR TITLE
Added support for Laravel 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~4.0|~5.0|~5.1|^6.0",
-        "laravel/framework": "~5.4|^6.0"
+        "illuminate/support": "~4.0|~5.0|~5.1|^6.0|^7.0",
+        "laravel/framework": "~5.4|^6.0|^7.0"
     },
     "autoload": {
         "classmap": [


### PR DESCRIPTION
Good news! Looks like no other changes are needed, other than supporting the proper version of ```illuminate/support``` and ```laravel/framework```. 

I've double-checked the upgrade guide, the only Eloquent changes that are remotely relevant are:
- ```getOriginal()``` changing to ```getOriginalRaw()``` 
- the added ```booting()``` and ```booted()``` methods

But ```revisionable``` doesn't use any of them, so we're fine.