### PR TITLE
Issue fixed for eloquent updateOrCreate with DB::raw

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -137,6 +137,10 @@ trait RevisionableTrait
                     unset($this->originalData[$key]);
                     unset($this->updatedData[$key]);
                     array_push($this->dontKeep, $key);
+                } else if (gettype($val) == 'object' && method_exists($val, '__toString') && isset($this->originalData[$key])) {
+                    $updatedData = $this->updatedData[$key]->__toString();
+
+                    $this->updatedData[$key] = $updatedData;
                 }
             }
 


### PR DESCRIPTION
Modified RevisionableTrait to fix the issue - Eloquent updateOrCreate with DB::raw triggers Object of class Illuminate/Database/Query/Expression could not be converted to int/float