### PR TITLE
Feature/dont destroy strings with cast

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,6 @@
             "email": "me@chrisduell.com"
         }
     ],
-    "abandoned": true,
     "support": {
         "issues": "https://github.com/VentureCraft/revisionable/issues",
         "source": "https://github.com/VentureCraft/revisionable"

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~4.0|~5.0|~5.1|^6.0",
-        "laravel/framework": "~5.4|^6.0"
+        "illuminate/support": "~4.0|~5.0|~5.1|^6.0|^7.0",
+        "laravel/framework": "~5.4|^6.0|^7.0"
     },
     "autoload": {
         "classmap": [

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~4.0|~5.0|~5.1",
+        "illuminate/support": "~4.0|~5.0|~5.1|^6.0",
         "laravel/framework": "~5.4"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -41,5 +41,5 @@
                 "Venturecraft\\Revisionable\\RevisionableServiceProvider"
             ]
         }
-    },
+    }
 }

--- a/readme.md
+++ b/readme.md
@@ -253,6 +253,14 @@ Booleans by default will display as a 0 or a 1, which is pretty bland and won't 
 boolean:No|Yes
 ```
 
+### Options
+Analogous to "boolean", only any text or numeric values can act as a source value (often flags are stored in the database). The format allows you to specify different outputs depending on the value.
+Look at this as an associative array in which the key is separated from the value by a dot. Array elements are separated by a vertical line.
+
+```
+options: search.On the search|network.In networks
+```
+
 ### DateTime
 DateTime by default will display as Y-m-d H:i:s. Prefix the value with `datetime:` and then add your datetime format, e.g.,
 

--- a/src/Venturecraft/Revisionable/FieldFormatter.php
+++ b/src/Venturecraft/Revisionable/FieldFormatter.php
@@ -117,4 +117,29 @@ class FieldFormatter
 
         return $datetime->format($format);
     }
+
+    /**
+     * Format options
+     *
+     * @param string $value
+     * @param string $format
+     * @return string
+     */
+    public static function options($value, $format)
+    {
+        $options = explode('|', $format);
+
+        $result = [];
+
+        foreach ($options as $option) {
+            $transform = explode('.', $option);
+            $result[$transform[0]] = $transform[1];
+        }
+
+        if (isset($result[$value])) {
+            return $result[$value];
+        }
+
+        return 'undefined';
+    }
 }

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -2,6 +2,7 @@
 
 namespace Venturecraft\Revisionable;
 
+use Illuminate\Support\Str;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 use Illuminate\Support\Facades\Log;
 
@@ -163,7 +164,7 @@ class Revision extends Eloquent
                     // Check if model use RevisionableTrait
                     if(method_exists($item, 'identifiableName')) {
                         // see if there's an available mutator
-                        $mutator = 'get' . studly_case($this->key) . 'Attribute';
+                        $mutator = 'get' . Str::studly($this->key) . 'Attribute';
                         if (method_exists($item, $mutator)) {
                             return $this->format($item->$mutator($this->key), $item->identifiableName());
                         }
@@ -179,7 +180,7 @@ class Revision extends Eloquent
             // if there was an issue
             // or, if it's a normal value
 
-            $mutator = 'get' . studly_case($this->key) . 'Attribute';
+            $mutator = 'get' . Str::studly($this->key) . 'Attribute';
             if (method_exists($main_model, $mutator)) {
                 return $this->format($this->key, $main_model->$mutator($this->$which_value));
             }

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -139,7 +139,7 @@ class Revision extends Eloquent
 
                     // Now we can find out the namespace of of related model
                     if (!method_exists($main_model, $related_model)) {
-                        $related_model = camel_case($related_model); // for cases like published_status_id
+                        $related_model = Str::camel($related_model); // for cases like published_status_id
                         if (!method_exists($main_model, $related_model)) {
                             throw new \Exception('Relation ' . $related_model . ' does not exist for ' . get_class($main_model));
                         }

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -1,5 +1,6 @@
 <?php namespace Venturecraft\Revisionable;
 
+use Illuminate\Support\Arr;
 use Illuminate\Database\Eloquent\Model as Eloquent;
 
 /*
@@ -153,7 +154,7 @@ class Revisionable extends Eloquent
                     'revisionable_type'     => $this->getMorphClass(),
                     'revisionable_id'       => $this->getKey(),
                     'key'                   => $key,
-                    'old_value'             => array_get($this->originalData, $key),
+                    'old_value'             => Arr::get($this->originalData, $key),
                     'new_value'             => $this->updatedData[$key],
                     'user_id'               => $this->getSystemUserId(),
                     'created_at'            => new \DateTime(),

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -1,5 +1,7 @@
 <?php namespace Venturecraft\Revisionable;
 
+use Illuminate\Support\Arr;
+
 /*
  * This file is part of the Revisionable package by Venture Craft
  *
@@ -188,7 +190,7 @@ trait RevisionableTrait
                     'revisionable_type' => $this->getMorphClass(),
                     'revisionable_id' => $this->getKey(),
                     'key' => $key,
-                    'old_value' => array_get($this->originalData, $key),
+                    'old_value' => Arr::get($this->originalData, $key),
                     'new_value' => $this->updatedData[$key],
                     'user_id' => $this->getSystemUserId(),
                     'created_at' => new \DateTime(),

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -125,7 +125,7 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-                if (isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
+                if (gettype($val) == 'object' && isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma
 


### PR DESCRIPTION
I recently upgraded from version 1.30.0 to 1.34.0 and found that a change to preSave() in 1.31.1 to check the attribute cast caused a problem with another trait.  We use an encryptable attribute trait on our models to encrypt values before they are stored in the database.  Some of these values are also cast as arrays.  The order of operations of the traits causes the values cast as array to be encrypted before Revisionable can act on the update events.  

The change to preSave() checks each model attribute to see if it's cast as an object so the key order can be normalized.  However, it doesn't verify the value is actually an object or array before using json_decode/json_encode.  Because the attribute was already encrypted the value is actually a string. 

I propose this change to verify that the cast value is actually an object before using json_decode() on the value.  This prevents json_decode from running on the encrypted string and destroying the value.  

Cheers