### PR TITLE
checks value is object before using json_decode() in preSave()

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -125,7 +125,8 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-                if (gettype($val) == 'object' && isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
+				$castCheck = ['object', 'array'];
+                if (isset($this->casts[$key]) && in_array(gettype($val), $castCheck) && in_array($this->casts[$key], $castCheck) && isset($this->originalData[$key])) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -125,7 +125,7 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-				$castCheck = ['object', 'array'];
+                $castCheck = ['object', 'array'];
                 if (isset($this->casts[$key]) && in_array(gettype($val), $castCheck) && in_array($this->casts[$key], $castCheck) && isset($this->originalData[$key])) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -125,7 +125,7 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-                if (isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
+                if (gettype($val) == 'object' && isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma
 


### PR DESCRIPTION
**  Re-posting to the master branch since "develope" seems to be way behind.

I recently upgraded from version 1.30.0 to 1.34.0 and found that a change to preSave() in 1.31.1 to check the attribute cast caused a problem with another trait. We use an encryptable attribute trait on our models to encrypt values before they are stored in the database. Some of these values are also cast as arrays. The order of operations of the traits causes the values cast as array to be encrypted before Revisionable can act on the update events.

The change to preSave() checks each model attribute to see if it's cast as an object so the key order can be normalized. However, it doesn't verify the value is actually an object or array before using json_decode/json_encode. Because the attribute was already encrypted the value is actually a string.

I propose this change to verify that the cast value is actually an object before using json_decode() on the value. This prevents json_decode from running on the encrypted string and destroying the value.

Cheers