### PR TITLE
Support non-default database connections

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -21,6 +21,15 @@ class Revision extends Eloquent
      */
     public $table = 'revisions';
 
+
+    /**
+     * @var array
+     */
+    protected $fillable = array(
+        'revisionable_type', 'revisionable_id', 'user_id', 'key', 'old_value', 'new_value',
+        'created_at', 'updated_at',
+    );
+
     /**
      * @var array
      */

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -164,8 +164,10 @@ class Revisionable extends Eloquent
             }
 
             if (count($revisions) > 0) {
-                $revision = static::newModel();
-                \DB::table($revision->getTable())->insert($revisions);
+                foreach ($revisions as $revisionData) {
+                    $revision = Revisionable::newModel();
+                    $revision->fill($revisionData)->save();
+                }
             }
         }
     }
@@ -197,8 +199,10 @@ class Revisionable extends Eloquent
                 'updated_at' => new \DateTime(),
             );
 
-            $revision = static::newModel();
-            \DB::table($revision->getTable())->insert($revisions);
+            foreach ($revisions as $revisionData) {
+                $revision = Revisionable::newModel();
+                $revision->fill($revisionData)->save();
+            }
         }
     }
 
@@ -220,8 +224,11 @@ class Revisionable extends Eloquent
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
             );
-            $revision = static::newModel();
-            \DB::table($revision->getTable())->insert($revisions);
+            
+            foreach ($revisions as $revisionData) {
+                $revision = Revisionable::newModel();
+                $revision->fill($revisionData)->save();
+            }
         }
     }
 
@@ -250,8 +257,10 @@ class Revisionable extends Eloquent
                 'updated_at' => new \DateTime(),
             );
 
-            $revision = Revisionable::newModel();
-            \DB::table($revision->getTable())->insert($revisions);
+            foreach ($revisions as $revisionData) {
+                $revision = Revisionable::newModel();
+                $revision->fill($revisionData)->save();
+            }
             \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
         }
     }


### PR DESCRIPTION
Support database connection declared by extended model class.

```
use Venturecraft\Revisionable\Revision as BaseRevision;

class Revision extends BaseRevision
{
    protected $connection = 'customeconnection';
}
```