### PR TITLE
Revert #112 and follow #113

### DIFF
--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -81,7 +81,12 @@ class Revisionable extends Eloquent
      */
     public static function newModel()
     {
-        $model = \Config::get('revisionable.model', 'Venturecraft\Revisionable\Revision');
+        $model = app('config')->get('revisionable.model');
+
+        if (! $model) {
+            $model = 'Venturecraft\Revisionable\Revision';
+        }
+
         return new $model;
     }
 


### PR DESCRIPTION
I'm using Lumen 5.8 and this call fails with Config class not found. However, using \Config elsewhere works and importing the facade works too.

Regardless, this is a better way to resolve the config and is already used elsewhere in the app.

Thanks!