### PR TITLE
Allow overwriting of `getRelatedModel()` method

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -214,7 +214,7 @@ class Revision extends Eloquent
      *
      * @return string
      */
-    private function getRelatedModel()
+    protected function getRelatedModel()
     {
         $idSuffix = '_id';
 


### PR DESCRIPTION
If the relationship of a model don't follow the default Laravel naming the package can't identify the correct relationship. Therefore, the method `identifiableName()` is not working:

Issue: #270

The package allow in the config to define an own revision model. My idea is to define a custom revision model and extend the package model. In the custom model I would overwrite the `getRelatedModel()` to adjust the logic to find the correct relationship.

The PR changes the visibility of the method to allow an overwriting.