### PR TITLE
Methods must return the same structure for the revisions array

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -249,7 +249,7 @@ trait RevisionableTrait
 
             $revision = Revisionable::newModel();
             \DB::table($revision->getTable())->insert($revisions);
-            \Event::dispatch('revisionable.created', array('model' => $this, 'revisions' => $revisions));
+            \Event::dispatch('revisionable.created', array('model' => $this, 'revisions' => [$revisions]));
         }
 
     }
@@ -279,7 +279,7 @@ trait RevisionableTrait
 
             $revision = Revisionable::newModel();
             \DB::table($revision->getTable())->insert($revisions);
-            \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
+            \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => [$revisions]));
         }
     }
 


### PR DESCRIPTION
After one of the last package updates, everything broke for me(( Because the postDelete() and postCreate() methods in the event now return "revisions" as a one-dimensional array, not a multidimensional one. I'm sure it's bad. The returned data must be of the same type. 
I suggest a correction.