### PR TITLE
Allow to get responsible when user is soft deleted

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -245,7 +245,7 @@ class Revision extends Eloquent
             if (!class_exists($user_model)) {
                 return false;
             }
-            return $user_model::find($this->user_id);
+            return $user_model::withTrashed()->find($this->user_id);
         }
     }
 


### PR DESCRIPTION
I've made a package that modify the users to allow to soft delete them.

When a user is soft deleted, the method `userResponsible` will return `null`, but the user is still in the database and is responsible for the revision. This can cause errors like "cannot get property ...... on null".

I've made my own `Revision` class to fix this, but I think this must be included by default because the user is responsible and must be loaded, deleted or not.

The fix is very simple, I just added `withTrashed` when getting the user.