### PR TITLE
Stop JSON data new_value being saved with slashes

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -193,7 +193,7 @@ trait RevisionableTrait
                     'revisionable_id' => $this->getKey(),
                     'key' => $key,
                     'old_value' => Arr::get($this->originalData, $key),
-                    'new_value' => $this->updatedData[$key],
+                    'new_value' => stripslashes($this->updatedData[$key]),
                     'user_id' => $this->getSystemUserId(),
                     'created_at' => new \DateTime(),
                     'updated_at' => new \DateTime(),


### PR DESCRIPTION
I'm keeping track of a JSON array, and I noticed the `new_value` was being saved with slashes. This was then being output on the frontend.

![2021-09-30-102627](https://user-images.githubusercontent.com/10615884/135382173-d0cc574c-a035-4cb2-a797-db9a388300c9.jpg)

I started messing with running `new_value` through a custom stripslashes function in blade files but seemed easier to just amend the package.

I used `stripslashes` on `new_value` in `postSave()` and it solves the problem. We've been running this for a while and haven't see anything else have issues because of this change. 

![2021-09-30-102920](https://user-images.githubusercontent.com/10615884/135382401-af2c88d5-8f84-42e9-a6d1-ff68c07a5bed.jpg)
