### PR TITLE
Use a morpahble for user resolving instead of static config resolving.

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -47,6 +47,16 @@ class Revision extends Eloquent
     }
 
     /**
+     * User Responsible.
+     *
+     * @return User user responsible for the change
+     */
+    public function user()
+    {
+        return $this->morphTo();
+    }
+
+    /**
      * Field Name
      *
      * Returns the field that was updated, in the case that it's a foreign key
@@ -228,25 +238,7 @@ class Revision extends Eloquent
      */
     public function userResponsible()
     {
-        if (empty($this->user_id)) { return false; }
-        if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
-            || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')
-        ) {
-            return $class::findUserById($this->user_id);
-        } else {
-            $user_model = app('config')->get('auth.model');
-
-            if (empty($user_model)) {
-                $user_model = app('config')->get('auth.providers.users.model');
-                if (empty($user_model)) {
-                    return false;
-                }
-            }
-            if (!class_exists($user_model)) {
-                return false;
-            }
-            return $user_model::find($this->user_id);
-        }
+        return $this->user;
     }
 
     /**

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -238,7 +238,28 @@ class Revision extends Eloquent
      */
     public function userResponsible()
     {
-        return $this->user;
+        if($this->user_type != null) {
+            return $this->user;
+        }
+        if (empty($this->user_id)) { return false; }
+        if (class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
+            || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')
+        ) {
+            return $class::findUserById($this->user_id);
+        } else {
+            $user_model = app('config')->get('auth.model');
+
+            if (empty($user_model)) {
+                $user_model = app('config')->get('auth.providers.users.model');
+                if (empty($user_model)) {
+                    return false;
+                }
+            }
+            if (!class_exists($user_model)) {
+                return false;
+            }
+            return $user_model::find($this->user_id);
+        }
     }
 
     /**

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -194,6 +194,7 @@ trait RevisionableTrait
                     'key' => $key,
                     'old_value' => Arr::get($this->originalData, $key),
                     'new_value' => $this->updatedData[$key],
+                    'user_type' => $this->getSystemUserType(),
                     'user_id' => $this->getSystemUserId(),
                     'created_at' => new \DateTime(),
                     'updated_at' => new \DateTime(),
@@ -238,6 +239,7 @@ trait RevisionableTrait
                 'key' => self::CREATED_AT,
                 'old_value' => null,
                 'new_value' => $this->{self::CREATED_AT},
+                'user_type' => $this->getSystemUserType(),
                 'user_id' => $this->getSystemUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
@@ -269,6 +271,7 @@ trait RevisionableTrait
                 'key' => $this->getDeletedAtColumn(),
                 'old_value' => null,
                 'new_value' => $this->{$this->getDeletedAtColumn()},
+                'user_type' => $this->getSystemUserType(),
                 'user_id' => $this->getSystemUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
@@ -303,6 +306,7 @@ trait RevisionableTrait
                 'key' => self::CREATED_AT,
                 'old_value' => $this->{self::CREATED_AT},
                 'new_value' => null,
+                'user_type' => $this->getSystemUserType(),
                 'user_id' => $this->getSystemUserId(),
                 'created_at' => new \DateTime(),
                 'updated_at' => new \DateTime(),
@@ -330,6 +334,30 @@ trait RevisionableTrait
                 return backpack_user()->id;
             } elseif (\Auth::check()) {
                 return \Auth::user()->getAuthIdentifier();
+            }
+        } catch (\Exception $e) {
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * Attempt to find the user class of the currently logged in user
+     * Supports Cartalyst Sentry/Sentinel based authentication, as well as stock Auth
+     **/
+    public function getSystemUserType()
+    {
+        try {
+            if (class_exists($class = '\SleepingOwl\AdminAuth\Facades\AdminAuth')
+                || class_exists($class = '\Cartalyst\Sentry\Facades\Laravel\Sentry')
+                || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')
+            ) {
+                return ($class::check()) ? get_class($class::getUser()) : null;
+            } elseif (function_exists('backpack_auth') && backpack_auth()->check()) {
+                return get_class(backpack_user());
+            } elseif (\Auth::check()) {
+                return get_class(\Auth::user());
             }
         } catch (\Exception $e) {
             return null;

--- a/src/migrations/2021_09_30_125124_add_user_type_to_revisions_table.php
+++ b/src/migrations/2021_09_30_125124_add_user_type_to_revisions_table.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddUserTypeToRevisionsTable extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('revisions', function (Blueprint $table) {
+            $table->string('user_type')->nullable();
+            $table->index(['user_id', 'user_type']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('revisions', function (Blueprint $table) {
+            $table->dropIndex(['user_id', 'user_type']);
+            $table->dropColumn('user_type');
+        });
+    }
+}


### PR DESCRIPTION
I'm currently developing an app with multiple auth providers.
Since revisionable uses a static provider set in config, I'm getting the wrong type of users.

I changed the user field into a morphable one so, the model can be created without the need of a resolver.
This adds a simple way of supporting multiple auth providers without breaking any installations.
I keep the original userResponsible() so it does not break history revisions which got created before the update.