### PR TITLE
Allow UUID being used for backpack users

### DIFF
--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -327,6 +327,9 @@ trait RevisionableTrait
             ) {
                 return ($class::check()) ? $class::getUser()->id : null;
             } elseif (function_exists('backpack_auth') && backpack_auth()->check()) {
+                if (backpack_user()->uuid) {
+                    return backpack_user()->uuid;
+                }
                 return backpack_user()->id;
             } elseif (\Auth::check()) {
                 return \Auth::user()->getAuthIdentifier();


### PR DESCRIPTION
In our projects, we use UUID to identify users instead of an ID. The change in 1.38.0 broke the listing of the ReviseOperation of Backpack.