### PR TITLE
Allow escaping | (pipe) and . (dot) for options string

### DIFF
--- a/src/Venturecraft/Revisionable/FieldFormatter.php
+++ b/src/Venturecraft/Revisionable/FieldFormatter.php
@@ -127,13 +127,15 @@ class FieldFormatter
      */
     public static function options($value, $format)
     {
-        $options = explode('|', $format);
+        $options= array_map(function($val) {
+            return str_replace('\\|', '|', $val);
+        }, preg_split('~(?<!\\\)' . preg_quote('|', '~') . '~', $format));
 
         $result = [];
 
         foreach ($options as $option) {
-            $transform = explode('.', $option);
-            $result[$transform[0]] = $transform[1];
+            $transform = preg_split('~(?<!\\\)' . preg_quote('.', '~') . '~', $option);
+            $result[$transform[0]] = str_replace('\\.', '.', $transform[1]);
         }
 
         if (isset($result[$value])) {


### PR DESCRIPTION
If the options string contains the explode delimiters, it will generate unexpected output. 
If the user needs pipe `|` or `.` in the options, this PR allows them to escape it.
Enhancement for #363 

Example String:
```
options:1.SA0000 - Kidd \|Tang|2.OKCRQ0 - Mr\. Carmine Fisher
```

Expected Output:
```
[
  1 => "SA0000 - Kidd |Tang"
  2 => "OKCRQ0 - Mr. Carmine Fisher"
]
```