### PR TITLE
Shouldn't use original data in postCreate

### DIFF
--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -290,4 +290,8 @@ class Revision extends Eloquent
             return $value;
         }
     }
+
+    public function user(){
+        return $this->belongsTo($this->getActualClassNameForMorph($this->revisionable_type), 'user_id','id');
+    }
 }

--- a/src/Venturecraft/Revisionable/Revision.php
+++ b/src/Venturecraft/Revisionable/Revision.php
@@ -292,6 +292,6 @@ class Revision extends Eloquent
     }
 
     public function user(){
-        return $this->belongsTo($this->getActualClassNameForMorph($this->revisionable_type), 'user_id','id');
+        return $this->belongsTo(app('config')->get('auth.model'), 'user_id','id');
     }
 }

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -245,7 +245,7 @@ trait RevisionableTrait
 
             //Determine if there are any additional fields we'd like to add to our model contained in the config file, and
             //get them into an array.
-            $revisions = array_merge($revisions[0], $this->getAdditionalFields());
+            $revisions = array_merge($revisions[0], $this->getAdditionalFields(false));
 
             $revision = Revisionable::newModel();
             \DB::table($revision->getTable())->insert($revisions);
@@ -339,15 +339,17 @@ trait RevisionableTrait
     }
 
 
-    public function getAdditionalFields()
+    public function getAdditionalFields($useOriginalData = true)
     {
         $additional = [];
+        // If this is coming from postCreate, we shouldn't use original data as there is no original data.
+        $dataToUse = $useOriginalData ? $this->originalData : $this->toArray();
         //Determine if there are any additional fields we'd like to add to our model contained in the config file, and
         //get them into an array.
         $fields = config('revisionable.additional_fields', []);
         foreach($fields as $field) {
-            if(Arr::has($this->originalData, $field)) {
-                $additional[$field]  =  Arr::get($this->originalData, $field);
+            if(Arr::has($dataToUse, $field)) {
+                $additional[$field]  =  Arr::get($dataToUse, $field);
             }
         }
 


### PR DESCRIPTION
I noticed that the old Revisionable class doesn't have the additional fields functionality, so I didn't add this there. This is a pretty straightforward operation. I'm making the assumption that whatever this trait is included in has a toArray() method, and that method returns an array.

The thought behind this is that during the postCreate function, $this->originalData will always be an empty array. If that is the case, we use $this->toArray(), or the current data.