### PR TITLE
Replaced DB query with eloquent so query uses model's $connection

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,14 @@
     "name": "venturecraft/revisionable",
     "license": "MIT",
     "description": "Keep a revision history for your models without thinking, created as a package for use with Laravel",
-    "keywords": ["model", "laravel", "ardent", "revision", "audit", "history"],
+    "keywords": [
+        "model",
+        "laravel",
+        "ardent",
+        "revision",
+        "audit",
+        "history"
+    ],
     "homepage": "http://github.com/venturecraft/revisionable",
     "authors": [
         {
@@ -16,8 +23,8 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~4.0|~5.0|~5.1|^6.0|^7.0|^8.0|^9.0",
-        "laravel/framework": "~5.4|^6.0|^7.0|^8.0|^9.0"
+        "illuminate/support": "~4.0|~5.0|~5.1|^6.0|^7.0|^8.0|^9.0|^10.0",
+        "laravel/framework": "~5.4|^6.0|^7.0|^8.0|^9.0|^10.0"
     },
     "autoload": {
         "classmap": [
@@ -33,7 +40,7 @@
         }
     },
     "require-dev": {
-        "orchestra/testbench": "~3.0"
+        "orchestra/testbench": "~3.0|^8.0"
     },
     "extra": {
         "laravel": {

--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,8 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "illuminate/support": "~4.0|~5.0|~5.1|^6.0|^7.0|^8.0",
-        "laravel/framework": "~5.4|^6.0|^7.0|^8.0"
+        "illuminate/support": "~4.0|~5.0|~5.1|^6.0|^7.0|^8.0|^9.0",
+        "laravel/framework": "~5.4|^6.0|^7.0|^8.0|^9.0"
     },
     "autoload": {
         "classmap": [

--- a/readme.md
+++ b/readme.md
@@ -344,7 +344,7 @@ If you have enabled revisions of creations as well you can display it like this:
 
 ### userResponsible()
 
-Returns the User that was responsible for making the revision. A user model is returned, or null if there was no user recorded.
+Returns the User that was responsible for making the revision. A user model is returned, or false if there was no user recorded.
 
 The user model that is loaded depends on what you have set in your `config/auth.php` file for the `model` variable.
 

--- a/readme.md
+++ b/readme.md
@@ -283,7 +283,7 @@ Analogous to "boolean", only any text or numeric values can act as a source valu
 Look at this as an associative array in which the key is separated from the value by a dot. Array elements are separated by a vertical line.
 
 ```
-options: search.On the search|network.In networks
+options:search.On the search|network.In networks
 ```
 
 ### DateTime

--- a/readme.md
+++ b/readme.md
@@ -162,6 +162,14 @@ To better format the output for `deleted_at` entries, you can use the `isEmpty` 
 
 <a name="control"></a>
 
+### Storing Force Delete
+By default the Force Delete of a model is not stored as a revision.
+
+If you want to store the Force Delete as a revision you can override this behavior by setting `revisionForceDeleteEnabled ` to `true` by adding the following to your model:
+```php
+protected $revisionForceDeleteEnabled = true;
+```
+
 ### Storing Creations
 By default the creation of a new model is not stored as a revision.
 Only subsequent changes to a model is stored.

--- a/readme.md
+++ b/readme.md
@@ -170,7 +170,7 @@ If you want to store the Force Delete as a revision you can override this behavi
 protected $revisionForceDeleteEnabled = true;
 ```
 
-In which case, the `created_at` field will be stored as a key with the `oldValue()` value equal to the model creation date and the `newValue()` value equal to null.
+In which case, the `created_at` field will be stored as a key with the `oldValue()` value equal to the model creation date and the `newValue()` value equal to `null`.
 
 **Attention!** Turn on this setting carefully! Since the model saved in the revision, now does not exist, so you will not be able to get its object or its relations. 
 

--- a/readme.md
+++ b/readme.md
@@ -170,6 +170,10 @@ If you want to store the Force Delete as a revision you can override this behavi
 protected $revisionForceDeleteEnabled = true;
 ```
 
+In which case, the `created_at` field will be stored as a key with the `oldValue()` value equal to the model creation date and the `newValue()` value equal to null.
+
+**Attention!** Turn on this setting carefully! Since the model saved in the revision, now does not exist, so you will not be able to get its object or its relations. 
+
 ### Storing Creations
 By default the creation of a new model is not stored as a revision.
 Only subsequent changes to a model is stored.

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -81,7 +81,12 @@ class Revisionable extends Eloquent
      */
     public static function newModel()
     {
-        $model = \Config::get('revisionable.model', 'Venturecraft\Revisionable\Revision');
+        $model = app('config')->get('revisionable.model');
+
+        if (! $model) {
+            $model = 'Venturecraft\Revisionable\Revision';
+        }
+
         return new $model;
     }
 

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -72,6 +72,7 @@ class Revisionable extends Eloquent
         static::deleted(function ($model) {
             $model->preSave();
             $model->postDelete();
+            $model->postForceDelete();
         });
     }
     /**
@@ -221,6 +222,37 @@ class Revisionable extends Eloquent
             );
             $revision = static::newModel();
             \DB::table($revision->getTable())->insert($revisions);
+        }
+    }
+
+    /**
+     * If forcedeletes are enabled, set the value created_at of model to null
+     *
+     * @return void|bool
+     */
+    public function postForceDelete()
+    {
+        if (empty($this->revisionForceDeleteEnabled)) {
+            return false;
+        }
+
+        if ((!isset($this->revisionEnabled) || $this->revisionEnabled)
+            && (($this->isSoftDelete() && $this->isForceDeleting()) || !$this->isSoftDelete())) {
+
+            $revisions[] = array(
+                'revisionable_type' => $this->getMorphClass(),
+                'revisionable_id' => $this->getKey(),
+                'key' => self::CREATED_AT,
+                'old_value' => $this->{self::CREATED_AT},
+                'new_value' => null,
+                'user_id' => $this->getSystemUserId(),
+                'created_at' => new \DateTime(),
+                'updated_at' => new \DateTime(),
+            );
+
+            $revision = Revisionable::newModel();
+            \DB::table($revision->getTable())->insert($revisions);
+            \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
         }
     }
 

--- a/src/Venturecraft/Revisionable/Revisionable.php
+++ b/src/Venturecraft/Revisionable/Revisionable.php
@@ -170,7 +170,8 @@ class Revisionable extends Eloquent
 
             if (count($revisions) > 0) {
                 $revision = static::newModel();
-                \DB::table($revision->getTable())->insert($revisions);
+                // \DB::table($revision->getTable())->insert($revisions);
+                $revision->insert($revisions);
             }
         }
     }
@@ -203,7 +204,8 @@ class Revisionable extends Eloquent
             );
 
             $revision = static::newModel();
-            \DB::table($revision->getTable())->insert($revisions);
+            // \DB::table($revision->getTable())->insert($revisions);
+            $revision->insert($revisions);
         }
     }
 
@@ -226,7 +228,8 @@ class Revisionable extends Eloquent
                 'updated_at' => new \DateTime(),
             );
             $revision = static::newModel();
-            \DB::table($revision->getTable())->insert($revisions);
+            // \DB::table($revision->getTable())->insert($revisions);
+            $revision->insert($revisions);
         }
     }
 
@@ -256,7 +259,8 @@ class Revisionable extends Eloquent
             );
 
             $revision = Revisionable::newModel();
-            \DB::table($revision->getTable())->insert($revisions);
+            // \DB::table($revision->getTable())->insert($revisions);
+            $revision->insert($revisions);
             \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
         }
     }

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -326,6 +326,8 @@ trait RevisionableTrait
                 || class_exists($class = '\Cartalyst\Sentinel\Laravel\Facades\Sentinel')
             ) {
                 return ($class::check()) ? $class::getUser()->id : null;
+            } elseif (function_exists('backpack_auth') && backpack_auth()->check()) {
+                return backpack_user()->id;
             } elseif (\Auth::check()) {
                 return \Auth::user()->getAuthIdentifier();
             }

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -126,7 +126,7 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-                if (isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
+                if (gettype($val) == 'object' && isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -126,7 +126,7 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-				$castCheck = ['object', 'array'];
+                $castCheck = ['object', 'array'];
                 if (isset($this->casts[$key]) && in_array(gettype($val), $castCheck) && in_array($this->casts[$key], $castCheck) && isset($this->originalData[$key])) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -126,7 +126,8 @@ trait RevisionableTrait
             // we can only safely compare basic items,
             // so for now we drop any object based items, like DateTime
             foreach ($this->updatedData as $key => $val) {
-                if (gettype($val) == 'object' && isset($this->casts[$key]) && in_array($this->casts[$key], ['object', 'array']) && isset($this->originalData[$key])) {
+				$castCheck = ['object', 'array'];
+                if (isset($this->casts[$key]) && in_array(gettype($val), $castCheck) && in_array($this->casts[$key], $castCheck) && isset($this->originalData[$key])) {
                     // Sorts the keys of a JSON object due Normalization performed by MySQL
                     // So it doesn't set false flag if it is changed only order of key or whitespace after comma
 

--- a/src/Venturecraft/Revisionable/RevisionableTrait.php
+++ b/src/Venturecraft/Revisionable/RevisionableTrait.php
@@ -210,7 +210,8 @@ trait RevisionableTrait
                     }
                 }
                 $revision = Revisionable::newModel();
-                \DB::table($revision->getTable())->insert($revisions);
+                // \DB::table($revision->getTable())->insert($revisions);
+                $revision->insert($revisions);
                 \Event::dispatch('revisionable.saved', array('model' => $this, 'revisions' => $revisions));
             }
         }
@@ -248,7 +249,8 @@ trait RevisionableTrait
             $revisions = array_merge($revisions[0], $this->getAdditionalFields());
 
             $revision = Revisionable::newModel();
-            \DB::table($revision->getTable())->insert($revisions);
+            // \DB::table($revision->getTable())->insert($revisions);
+            $revision->insert($revisions);
             \Event::dispatch('revisionable.created', array('model' => $this, 'revisions' => $revisions));
         }
 
@@ -278,7 +280,8 @@ trait RevisionableTrait
             $revisions = array_merge($revisions[0], $this->getAdditionalFields());
 
             $revision = Revisionable::newModel();
-            \DB::table($revision->getTable())->insert($revisions);
+            // \DB::table($revision->getTable())->insert($revisions);
+            $revision->insert($revisions);
             \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
         }
     }
@@ -309,7 +312,8 @@ trait RevisionableTrait
             );
 
             $revision = Revisionable::newModel();
-            \DB::table($revision->getTable())->insert($revisions);
+            // \DB::table($revision->getTable())->insert($revisions);
+            $revision->insert($revisions);
             \Event::dispatch('revisionable.deleted', array('model' => $this, 'revisions' => $revisions));
         }
     }

--- a/src/migrations/2013_04_09_062329_create_revisions_table.php
+++ b/src/migrations/2013_04_09_062329_create_revisions_table.php
@@ -12,10 +12,10 @@ class CreateRevisionsTable extends Migration
     public function up()
     {
         Schema::create('revisions', function ($table) {
-            $table->increments('id');
+            $table->bigIncrements('id');
             $table->string('revisionable_type');
-            $table->integer('revisionable_id');
-            $table->integer('user_id')->nullable();
+            $table->unsignedBigInteger('revisionable_id');
+            $table->unsignedBigInteger('user_id')->nullable();
             $table->string('key');
             $table->text('old_value')->nullable();
             $table->text('new_value')->nullable();
@@ -32,6 +32,6 @@ class CreateRevisionsTable extends Migration
      */
     public function down()
     {
-        Schema::drop('revisions');
+        Schema::dropIfExists('revisions');
     }
 }


### PR DESCRIPTION
Replacing a DB query with Eloquent ensures the query utilizes the Revision model's $connection property, which defines the database connection. This helps if we want to use different database connection for revisions table.